### PR TITLE
Fetch OLDs from server

### DIFF
--- a/src/dativerf/core.cljs
+++ b/src/dativerf/core.cljs
@@ -22,6 +22,7 @@
 (defn init []
   (routes/start!)
   (re-frame/dispatch-sync [::events/initialize-db])
+  (re-frame/dispatch-sync [::events/fetch-olds])
   (re-frame/dispatch-sync [::rp/add-keyboard-event-listener "keydown"])
   (dev-setup)
   (mount-root))

--- a/src/dativerf/db.cljs
+++ b/src/dativerf/db.cljs
@@ -1,19 +1,16 @@
 (ns dativerf.db)
 
 (def test-sample-olds
-  [{:id "blaold"
-    :name "Blackfoot OLD"
+  [{:name "Blackfoot OLD"
     :url "https://app.onlinelinguisticdatabase.org/blaold"}
-   {:id "okaold"
-    :name "Okanagan OLD"
+   {:name "Okanagan OLD"
     :url "https://app.onlinelinguisticdatabase.org/okaold"}])
 
 (def default-db
   {:name "Dative"
    :active-tab :home
-   ;; :olds []
-   :old (-> test-sample-olds first :id)
-   :olds test-sample-olds
+   :olds []
+   :old nil
    :old-states {}
    :user nil
    :application-settings nil
@@ -24,4 +21,4 @@
    :login/invalid-reason nil})
 
 (defn old [{:keys [old olds]}]
-  (->> olds (filter (fn [{:keys [id]}] (= old id))) first))
+  (->> olds (filter (fn [{:keys [url]}] (= old url))) first))

--- a/src/dativerf/events.cljs
+++ b/src/dativerf/events.cljs
@@ -5,6 +5,7 @@
    [dativerf.db :as db]
    [dativerf.fsms :as fsms]
    [dativerf.fsms.login :as login]
+   [dativerf.models.old :as models-old]
    [dativerf.old :as old]
    [dativerf.utils :as utils]
    [day8.re-frame.tracing :refer-macros [fn-traced defn-traced]]
@@ -20,6 +21,31 @@
 (re-frame/reg-event-fx
  ::navigate
  (fn-traced [_ [_ handler]] {:navigate handler}))
+
+(def app-dative-servers-url "https://app.dative.ca/servers.json")
+
+(re-frame/reg-event-fx
+ ::fetch-olds
+ (fn-traced [_cofx _event]
+            {:http-xhrio
+             {:method :get
+              :uri app-dative-servers-url
+              :format (ajax/json-request-format)
+              :response-format (ajax/json-response-format {:keywords? true})
+              :on-success [::olds-fetched]
+              :on-failure [::olds-not-fetched]}}))
+
+(re-frame/reg-event-db
+ ::olds-fetched
+ (fn-traced [db [_ olds]]
+            (assoc db :olds (models-old/olds-response->olds olds))))
+
+(re-frame/reg-event-db
+ ::olds-not-fetched
+ (fn-traced [db [_ response]]
+            (println "WARNING: failed to fetch the olds from the server!")
+            (prn response)
+            db))
 
 (re-frame/reg-event-fx
  ::set-active-tab

--- a/src/dativerf/models/old.cljs
+++ b/src/dativerf/models/old.cljs
@@ -1,0 +1,13 @@
+(ns dativerf.models.old
+  (:require [dativerf.specs :as specs]
+            [dativerf.utils :as utils]
+            [clojure.spec.alpha :as s]))
+
+(defn olds-response->olds [olds-response]
+  (let [olds (utils/->kebab-case-recursive olds-response)
+        explain-data (s/explain-data ::specs/olds olds)]
+    (when explain-data
+      (throw (ex-info "OLDs from server are malformed"
+                      {:olds olds
+                       :explain-data explain-data})))
+    olds))

--- a/src/dativerf/specs.cljs
+++ b/src/dativerf/specs.cljs
@@ -1,0 +1,12 @@
+(ns dativerf.specs
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
+
+(s/def ::non-empty-string (s/and string? (complement str/blank?)))
+
+(s/def :old/name ::non-empty-string)
+(s/def :old/url ::non-empty-string)
+(s/def ::old (s/keys :req-un [:old/name
+                              :old/url]))
+(s/def ::olds (s/coll-of ::old))
+

--- a/src/dativerf/subs.cljs
+++ b/src/dativerf/subs.cljs
@@ -5,7 +5,7 @@
 
 (re-frame/reg-sub ::name (fn [db] (:name db)))
 (re-frame/reg-sub ::old (fn [db] (:old db)))
-(re-frame/reg-sub ::olds (fn [db] (:olds db)))
+(re-frame/reg-sub ::olds (fn [db] (->> db :olds (sort-by :name))))
 (re-frame/reg-sub ::active-tab (fn [db _] (:active-tab db)))
 (re-frame/reg-sub ::re-pressed-example (fn [db _] (:re-pressed-example db)))
 (re-frame/reg-sub ::user (fn [db] (:user db)))

--- a/src/dativerf/views.cljs
+++ b/src/dativerf/views.cljs
@@ -1,20 +1,19 @@
 (ns dativerf.views
-  (:require
-   [re-frame.core :as re-frame]
-   [re-com.core :as re-com :refer [at]]
-   [dativerf.styles :as styles]
-   [dativerf.events :as events]
-   [dativerf.routes :as routes]
-   [dativerf.subs :as subs]
-   dativerf.views.home
-   dativerf.views.login))
+  (:require [re-frame.core :as re-frame]
+            [re-com.core :as re-com :refer [at]]
+            [dativerf.events :as events]
+            [dativerf.routes :as routes]
+            [dativerf.styles :as styles]
+            [dativerf.subs :as subs]
+            dativerf.views.home
+            dativerf.views.login))
 
 (defn title []
   (let [user @(re-frame/subscribe [::subs/user])
         old-id @(re-frame/subscribe [::subs/old])
         olds @(re-frame/subscribe [::subs/olds])
         old-name (some->> olds
-                          (filter (fn [o] (= old-id (:id o))))
+                          (filter (fn [o] (= old-id (:url o))))
                           first
                           :name)
         title (if (and user old-name)

--- a/src/dativerf/views/login.cljs
+++ b/src/dativerf/views/login.cljs
@@ -34,6 +34,7 @@
              :choices @(re-frame/subscribe [::subs/olds])
              :model @(re-frame/subscribe [::subs/old])
              :label-fn :name
+             :id-fn :url
              :filter-box? true
              :on-change
              (fn [x]


### PR DESCRIPTION
Fixes #11 

## Considerations

We should probably start caching things like these OLDs in localStorage (maybe using [re-frame-storage](https://github.com/akiroz/re-frame-storage)) but I think we can leave that for later work.

## Changes

- On app initialization, we fetch the OLDs as JSON from the old Dative app at https://app.dative.ca.
- Validate these OLDs and use them to populate the OLD select widget during login.