### PR TITLE
Add ability to view a single form & routing improvements

### DIFF
--- a/docs/design.rst
+++ b/docs/design.rst
@@ -2,6 +2,7 @@
   DativeRF Design Document
 ================================================================================
 
+
 Requirements
 ================================================================================
 
@@ -18,13 +19,13 @@ In Progress
 Ready
 --------------------------------------------------------------------------------
 
-- The authenticated OLD's application settings should be displayed at a URL path
-  that contains the OLD slug.
 
 
 Backlog
 --------------------------------------------------------------------------------
 
+- Successful authentication should result in the home page of the authenticated
+  OLD being rendered under the home tab.
 - URLs should work on page refresh or on a fresh page. Currently they do not.
   One reason is that the in-memory DB is lost and therefore the authenticated
   OLD cannot be retrieved.
@@ -36,6 +37,8 @@ Backlog
   - Allow for some manual control over this. For example, a user could hold
     command when clicking the "Forms" tab or a navigation button to ignore
     the cache.
+  - This applies to other OLD resources also, not just forms. For example, the
+    OLD's application-settings cache needs to be invalidated also.
 
 - It should be possible to manage authentication more easily in DativeRF.
 
@@ -48,6 +51,8 @@ Backlog
 Done
 --------------------------------------------------------------------------------
 
+- DONE. The authenticated OLD's application settings should be displayed at a
+  URL path that contains the OLD slug.
 - DONE. When a user is logged out, we route them to the login GUI but the path
   still shows the /oldslug/logout path. It should show the /login path.
 - DONE. The db ns needs a utility for accessing the slug of the authenticated

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -5,17 +5,21 @@
 Requirements
 ================================================================================
 
+These requirements are not exhaustive. I am using them right now as a simple
+kanban board and to keep track of a backlog of ideas. For the "Dative v2 MVP"
+project, there is a private GitHub project board at
+https://github.com/orgs/dativebase/projects/10.
+
+
 In Progress
 --------------------------------------------------------------------------------
-
-- Utilities for constructing route maps should be defined in the routes ns.
-
-   - Right now, the events ns contains a lot of duplicative boilerplate around
-     constructing routes.
 
 
 Ready
 --------------------------------------------------------------------------------
+
+- The authenticated OLD's application settings should be displayed at a URL path
+  that contains the OLD slug.
 
 
 Backlog
@@ -24,7 +28,6 @@ Backlog
 - URLs should work on page refresh or on a fresh page. Currently they do not.
   One reason is that the in-memory DB is lost and therefore the authenticated
   OLD cannot be retrieved.
-
 - Form navigation should use its cache so that network requests are made when
   appropriate.
 
@@ -45,6 +48,10 @@ Backlog
 Done
 --------------------------------------------------------------------------------
 
+- DONE. When a user is logged out, we route them to the login GUI but the path
+  still shows the /oldslug/logout path. It should show the /login path.
+- DONE. The db ns needs a utility for accessing the slug of the authenticated
+  OLD. This will make the events ns more clear, I think.
 - DONE. It should be possible to visit a form at this url, e.g., /forms/1
 - DONE. Each page should have a unique URL.
 
@@ -56,7 +63,6 @@ Done
 
 - DONE. The URL should indicate the authenticated OLD, e.g., /blaold/forms/1
   should resolve to a display of the form with ID = 1 of the Blackfoot OLD.
-
 - DONE. Unnecessary data should not be gathered up front.
 
   - DONE. For example, previously we were fetching an OLD's application

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -1,0 +1,44 @@
+================================================================================
+  DativeRF Design Document
+================================================================================
+
+Requirements
+================================================================================
+
+- Each page should have a unique URL.
+
+  - It should be possible to visit a form at this url, e.g., /forms/1
+  - DONE. It should be possible to browse the most recent page of forms at this
+    URL, e.g., /forms.
+  - DONE. It should be possible to browse a specific page of forms at this URL,
+    e.g., /forms/page/1/items-per-page/5
+
+- Form navigation should use its cache so that network requests are made when
+  appropriate.
+
+  - If the forms for a page are present in memory and they are not stale
+    (threshold), use the in-memory data instead of making a request.
+  - Allow for some manual control over this. For example, a user could hold
+    command when clicking the "Forms" tab or a navigation button to ignore
+    the cache.
+
+- The URL should indicate the authenticated OLD, e.g., /blaold/forms/1 should
+  resolve to a display of the form with ID = 1 of the Blackfoot OLD.
+
+- It should be possible to manage authentication more easily in DativeRF.
+
+  - It should be possible to switch between OLDs more easily.
+  - It should be clear which OLDs have valid cookies, i.e., which are
+    authenticated.
+  - A failure to de-authenticated should never break the app.
+
+- Unnecessary data should not be gathered up front.
+
+  - For example, previously we were fetching an OLD's application settings, its
+    data to create a new form, and its data to create a new form search upon
+    every login.
+
+ - Utilities for constructing route maps should be defined in the routes ns.
+
+   - Right now, the events ns contains a lot of duplicative boilerplate around
+     constructing routes.

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -5,13 +5,25 @@
 Requirements
 ================================================================================
 
-- Each page should have a unique URL.
+In Progress
+--------------------------------------------------------------------------------
 
-  - It should be possible to visit a form at this url, e.g., /forms/1
-  - DONE. It should be possible to browse the most recent page of forms at this
-    URL, e.g., /forms.
-  - DONE. It should be possible to browse a specific page of forms at this URL,
-    e.g., /forms/page/1/items-per-page/5
+- Utilities for constructing route maps should be defined in the routes ns.
+
+   - Right now, the events ns contains a lot of duplicative boilerplate around
+     constructing routes.
+
+
+Ready
+--------------------------------------------------------------------------------
+
+
+Backlog
+--------------------------------------------------------------------------------
+
+- URLs should work on page refresh or on a fresh page. Currently they do not.
+  One reason is that the in-memory DB is lost and therefore the authenticated
+  OLD cannot be retrieved.
 
 - Form navigation should use its cache so that network requests are made when
   appropriate.
@@ -22,9 +34,6 @@ Requirements
     command when clicking the "Forms" tab or a navigation button to ignore
     the cache.
 
-- The URL should indicate the authenticated OLD, e.g., /blaold/forms/1 should
-  resolve to a display of the form with ID = 1 of the Blackfoot OLD.
-
 - It should be possible to manage authentication more easily in DativeRF.
 
   - It should be possible to switch between OLDs more easily.
@@ -32,13 +41,24 @@ Requirements
     authenticated.
   - A failure to de-authenticated should never break the app.
 
-- Unnecessary data should not be gathered up front.
 
-  - For example, previously we were fetching an OLD's application settings, its
-    data to create a new form, and its data to create a new form search upon
-    every login.
+Done
+--------------------------------------------------------------------------------
 
- - Utilities for constructing route maps should be defined in the routes ns.
+- DONE. It should be possible to visit a form at this url, e.g., /forms/1
+- DONE. Each page should have a unique URL.
 
-   - Right now, the events ns contains a lot of duplicative boilerplate around
-     constructing routes.
+  - DONE. When form 1 is displayed, the URL path should display /forms/1.
+  - DONE. When the most recent page of forms is displayed, the URL path should
+    display /forms.
+  - DONE. When a specific page of forms is displayed, the URL path should
+    display /forms/page/1/items-per-page/5, for example.
+
+- DONE. The URL should indicate the authenticated OLD, e.g., /blaold/forms/1
+  should resolve to a display of the form with ID = 1 of the Blackfoot OLD.
+
+- DONE. Unnecessary data should not be gathered up front.
+
+  - DONE. For example, previously we were fetching an OLD's application
+    settings, its data to create a new form, and its data to create a new form
+    search upon every login.

--- a/src/dativerf/db.cljs
+++ b/src/dativerf/db.cljs
@@ -31,9 +31,12 @@
    :forms/labels-on? false
    :forms/expanded? false
    ;; routing state
-   :forms/previous-route nil})
+   :forms/previous-route nil
+   :forms/previous-browse-route nil
+   :old-settings/previous-route nil})
 
 (defn old [{:keys [old olds]}]
   (->> olds (filter (fn [{:keys [url]}] (= old url))) first))
 
 (defn old-slug [db] (:slug (old db)))
+(defn old-name [db] (:name (old db)))

--- a/src/dativerf/db.cljs
+++ b/src/dativerf/db.cljs
@@ -8,7 +8,7 @@
 
 (def default-db
   {:name "Dative"
-   :active-tab :home
+   :active-route {:handler :home}
    :olds []
    :old nil
    :old-states {}
@@ -24,12 +24,14 @@
    :forms-paginator/items-per-page 10
    :forms-paginator/current-page-forms []
    :forms-paginator/current-page 1
-   :forms-paginator/last-page 1
+   :forms-paginator/last-page nil
    :forms-paginator/count 0
    :forms-paginator/first-form 0
    :forms-paginator/last-form 0
    :forms/labels-on? false
-   :forms/expanded? false})
+   :forms/expanded? false
+   ;; routing state
+   :forms/previous-route nil})
 
 (defn old [{:keys [old olds]}]
   (->> olds (filter (fn [{:keys [url]}] (= old url))) first))

--- a/src/dativerf/db.cljs
+++ b/src/dativerf/db.cljs
@@ -35,3 +35,5 @@
 
 (defn old [{:keys [old olds]}]
   (->> olds (filter (fn [{:keys [url]}] (= old url))) first))
+
+(defn old-slug [db] (:slug (old db)))

--- a/src/dativerf/models/old.cljs
+++ b/src/dativerf/models/old.cljs
@@ -1,7 +1,16 @@
 (ns dativerf.models.old
   (:require [dativerf.specs :as specs]
             [dativerf.utils :as utils]
-            [clojure.spec.alpha :as s]))
+            [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
+
+
+(defn url->slug [url]
+  (-> url
+      (str/trim)
+      (str/replace #"/+$" "")
+      (str/split #"/")
+      last))
 
 (defn olds-response->olds [olds-response]
   (let [olds (utils/->kebab-case-recursive olds-response)
@@ -10,4 +19,8 @@
       (throw (ex-info "OLDs from server are malformed"
                       {:olds olds
                        :explain-data explain-data})))
-    olds))
+    (mapv (fn [{:keys [name url]}]
+            {:name name
+             :url url
+             :slug (url->slug url)})
+          olds)))

--- a/src/dativerf/old.cljs
+++ b/src/dativerf/old.cljs
@@ -10,5 +10,6 @@
 (defn forms-new [old] (str (url old) "forms/new"))
 (defn formsearches-new [old] (str (url old) "formsearches/new"))
 (defn forms [old] (str (url old) "forms"))
+(defn form [old id] (str (url old) "forms/" id))
 (defn login-authenticate [old] (str (url old) "login/authenticate"))
 (defn login-logout [old] (str (url old) "login/logout"))

--- a/src/dativerf/routes.cljs
+++ b/src/dativerf/routes.cljs
@@ -20,8 +20,9 @@
            "/" {[:id] :form-page}}
           "/files" :files
           "/logout" :logout
-          "/settings" :settings}
-         "application-settings" :application-settings}]))
+          "/settings"
+          {"" :old-settings
+           "/input-validation" :old-settings-input-validation}}}]))
 
 (defmulti tabs :handler)
 

--- a/src/dativerf/routes.cljs
+++ b/src/dativerf/routes.cljs
@@ -17,7 +17,7 @@
            {[:page]
             {"/items-per-page/"
              {[:items-per-page] :forms-page}}}
-           [:id] :form-id}
+           "/" {[:id] :form-page}}
           "/files" :files
           "/logout" :logout
           "/settings" :settings}

--- a/src/dativerf/specs.cljs
+++ b/src/dativerf/specs.cljs
@@ -9,4 +9,3 @@
 (s/def ::old (s/keys :req-un [:old/name
                               :old/url]))
 (s/def ::olds (s/coll-of ::old))
-

--- a/src/dativerf/subs.cljs
+++ b/src/dativerf/subs.cljs
@@ -1,12 +1,14 @@
 (ns dativerf.subs
   (:require
    [re-frame.core :as re-frame]
+   [dativerf.db :as db]
    [dativerf.fsms.login :as login]))
 
 (re-frame/reg-sub ::name (fn [db] (:name db)))
 (re-frame/reg-sub ::old (fn [db] (:old db)))
+(re-frame/reg-sub ::old-slug (fn [db] (-> db db/old :slug)))
 (re-frame/reg-sub ::olds (fn [db] (->> db :olds (sort-by :name))))
-(re-frame/reg-sub ::active-tab (fn [db _] (:active-tab db)))
+(re-frame/reg-sub ::active-route (fn [db _] (:active-route db)))
 (re-frame/reg-sub ::re-pressed-example (fn [db _] (:re-pressed-example db)))
 (re-frame/reg-sub ::user (fn [db] (:user db)))
 
@@ -76,6 +78,8 @@
 (re-frame/reg-sub ::forms-last-form
                   (fn [db _] (:forms-paginator/last-form db)))
 
+(re-frame/reg-sub ::forms-previous-route
+                  (fn [db _] (:forms/previous-route db)))
 (re-frame/reg-sub ::forms-labels-on?
                   (fn [db _] (:forms/labels-on? db)))
 

--- a/src/dativerf/subs.cljs
+++ b/src/dativerf/subs.cljs
@@ -20,7 +20,7 @@
 (re-frame/reg-sub :login/invalid-reason (fn [db _] (:login/invalid-reason db)))
 
 (re-frame/reg-sub
- ::application-settings
+ ::old-settings
  (fn [db _]
    (get-in db [:old-states (:old db) :application-settings])))
 
@@ -82,6 +82,8 @@
                   (fn [db _] (:forms/previous-route db)))
 (re-frame/reg-sub ::forms-labels-on?
                   (fn [db _] (:forms/labels-on? db)))
+(re-frame/reg-sub ::old-settings-previous-route
+                  (fn [db _] (:old-settings/previous-route db)))
 
 (re-frame/reg-sub ::form-by-id
                   (fn [db [_ form-id]]

--- a/src/dativerf/subs.cljs
+++ b/src/dativerf/subs.cljs
@@ -87,6 +87,13 @@
                   (fn [db [_ form-id]]
                     (get-in db [:old-states (:old db) :forms form-id])))
 
+(re-frame/reg-sub ::form-by-int-id
+                  (fn [db [_ form-id]]
+                    (->> (get-in db [:old-states (:old db) :forms])
+                         vals
+                         (filter (fn [{:keys [id]}] (= form-id id)))
+                         first)))
+
 (re-frame/reg-sub ::form-expanded?
                   (fn [db [_ form-id]]
                     (-> db

--- a/src/dativerf/utils.cljs
+++ b/src/dativerf/utils.cljs
@@ -22,13 +22,17 @@
 (def handler->tab
   {:forms-last-page :forms
    :form-page :forms
-   :forms-page :forms})
+   :forms-page :forms
+   :old-settings-input-validation :old-settings})
 
 (def tab->handler
   {:forms :forms-last-page})
 
 (defn forms-route? [{:keys [handler]}]
-  (= :forms (handler handler->tab)))
+  (= :forms (handler handler->tab handler)))
 
 (defn forms-browse-route? [{:keys [handler]}]
   (some #{handler} [:forms-last-page :forms-page]))
+
+(defn old-settings-route? [{:keys [handler]}]
+  (= :old-settings (handler handler->tab handler)))

--- a/src/dativerf/utils.cljs
+++ b/src/dativerf/utils.cljs
@@ -18,3 +18,17 @@
              (csk/->kebab-case x))
            x))
    d))
+
+(def handler->tab
+  {:forms-last-page :forms
+   :form-page :forms
+   :forms-page :forms})
+
+(def tab->handler
+  {:forms :forms-last-page})
+
+(defn forms-route? [{:keys [handler]}]
+  (= :forms (handler handler->tab)))
+
+(defn forms-browse-route? [{:keys [handler]}]
+  (some #{handler} [:forms-last-page :forms-page]))

--- a/src/dativerf/views.cljs
+++ b/src/dativerf/views.cljs
@@ -6,6 +6,7 @@
             [dativerf.routes :as routes]
             [dativerf.styles :as styles]
             [dativerf.subs :as subs]
+            [dativerf.utils :as utils]
             dativerf.views.application-settings
             dativerf.views.forms
             dativerf.views.home
@@ -64,17 +65,10 @@
                 (nil? authenticated?)))
           tabs))
 
-(def handler->tab
-  {:forms-last-page :forms
-   :forms-page :forms})
-
-(def tab->handler
-  {:forms :forms-last-page})
-
 (defn menu []
   (let [user @(re-frame/subscribe [::subs/user])
         {:as route :keys [handler]} @(re-frame/subscribe [::subs/active-route])
-        tab (get handler->tab handler handler)
+        tab (get utils/handler->tab handler handler)
         old @(re-frame/subscribe [::subs/old])
         olds @(re-frame/subscribe [::subs/olds])
         authenticated? (boolean user)
@@ -91,17 +85,17 @@
        (re-frame/dispatch
         (let [[tab-map] (for [tm tabs :when (= tab-id (:id tm))] tm)
               forms-previous-route @(re-frame/subscribe [::subs/forms-previous-route])
-              handler (get tab->handler tab-id tab-id)
+              handler (get utils/tab->handler tab-id tab-id)
               route
               (cond (and (= :forms tab-id)
                          forms-previous-route)
                     forms-previous-route
                     (:old-specific? tab-map)
-                    {:handler (get tab->handler tab-id tab-id)
+                    {:handler (get utils/tab->handler tab-id tab-id)
                      :route-params
                      {:old (:slug (db/old {:old old :olds olds}))}}
                     :else
-                    {:handler (get tab->handler tab-id tab-id)})]
+                    {:handler (get utils/tab->handler tab-id tab-id)})]
           [::events/navigate route])))]))
 
 (defn main-tab []

--- a/src/dativerf/views/form.cljs
+++ b/src/dativerf/views/form.cljs
@@ -214,9 +214,12 @@
      [re-com/hyperlink
       :label (str id)
       :on-click (fn [& x]
-                  ;; TODO
-                  (println x)
-                  (println "visit this form"))
+                  (re-frame/dispatch
+                   [::events/navigate
+                    {:handler :form-page
+                     :route-params
+                     {:old @(re-frame/subscribe [::subs/old-slug])
+                      :id id}}]))
       :tooltip "view this form"]]]])
 
 (defn tags-as-string [tags]

--- a/src/dativerf/views/form.cljs
+++ b/src/dativerf/views/form.cljs
@@ -202,6 +202,23 @@
        :max-width form-value-width
        :child (str value)]]]))
 
+(defn id-string
+  [id]
+  [re-com/h-box
+   :src (at)
+   :children
+   [[igt-label (or (-> :id attrs :label) "")]
+    [re-com/box
+     :max-width form-value-width
+     :child
+     [re-com/hyperlink
+      :label (str id)
+      :on-click (fn [& x]
+                  ;; TODO
+                  (println x)
+                  (println "visit this form"))
+      :tooltip "view this form"]]]])
+
 (defn tags-as-string [tags]
   (when (seq tags)
     [re-com/h-box
@@ -333,7 +350,7 @@
     [secondary-scalar :semantics semantics]
     [secondary-scalar :syntax syntax]
     [secondary-scalar :uuid uuid]
-    [secondary-scalar :id id]]])
+    [id-string id]]])
 
 (defn igt-form [form-id]
   (let [form (form-specs/parse-form @(re-frame/subscribe

--- a/src/dativerf/views/forms.cljs
+++ b/src/dativerf/views/forms.cljs
@@ -132,6 +132,14 @@
    :on-click (fn [_] (re-frame/dispatch
                       [::events/user-clicked-forms-labels-button]))])
 
+(defn back-to-browse-button []
+  [re-com/md-circle-icon-button
+   :md-icon-name "zmdi-fast-rewind"
+   :size :smaller
+   :tooltip "back to forms browse"
+   :on-click (fn [_] (re-frame/dispatch
+                      [::events/user-clicked-back-to-browse-button]))])
+
 (defn help-button []
   [re-com/md-circle-icon-button
    :md-icon-name "zmdi-help"
@@ -317,6 +325,23 @@
    [[browse-navigation]
     [forms-enumeration]]])
 
+(defn- form-navigation []
+  [re-com/h-box
+   :src (at)
+   :gap "5px"
+   :size "auto"
+   :children [[back-to-browse-button]
+              [labels-button]]])
+
+(defn- form-tab [form]
+  [re-com/v-box
+   :src (at)
+   :gap "1em"
+   :padding "1em"
+   :children
+   [[form-navigation]
+    [form/igt-form (:uuid form)]]])
+
 (defmethod routes/tabs :forms-page
   [{{:keys [page items-per-page]} :route-params}]
   (let [current-page @(re-frame/subscribe [::subs/forms-current-page])
@@ -346,3 +371,10 @@
         (assoc-in (forms-page-route) [:route-params :page] last-page)])
       (do (re-frame/dispatch [::events/fetch-forms-last-page])
           [re-com/throbber :size :large]))))
+
+(defmethod routes/tabs :form-page [{{:keys [id]} :route-params}]
+  (if-let [form @(re-frame/subscribe [::subs/form-by-int-id (js/parseInt id)])]
+    [form-tab form]
+    (do
+      (re-frame/dispatch [::events/fetch-form id])
+      [re-com/throbber :size :large])))

--- a/src/dativerf/views/login.cljs
+++ b/src/dativerf/views/login.cljs
@@ -61,7 +61,7 @@
       :placeholder "username"
       :model @(re-frame/subscribe [:login/username])
       :disabled? @(re-frame/subscribe [:login/inputs-disabled?])
-      :on-change (fn [username] (re-frame/dispatch
+      :on-change (fn [username] (re-frame/dispatch-sync
                                  [::events/user-changed-username
                                   username]))]]))
 
@@ -81,7 +81,7 @@
       :change-on-blur? false
       :model @(re-frame/subscribe [:login/password])
       :disabled? @(re-frame/subscribe [:login/inputs-disabled?])
-      :on-change (fn [password] (re-frame/dispatch
+      :on-change (fn [password] (re-frame/dispatch-sync
                                  [::events/user-changed-password
                                   password]))]]))
 

--- a/src/dativerf/views/old_settings.cljs
+++ b/src/dativerf/views/old_settings.cljs
@@ -1,6 +1,7 @@
-(ns dativerf.views.application-settings
+(ns dativerf.views.old-settings
   (:require [re-frame.core :as re-frame]
             [re-com.core :as re-com :refer [at]]
+            [dativerf.db :as db]
             [dativerf.events :as events]
             [dativerf.routes :as routes]
             [dativerf.subs :as subs]
@@ -8,10 +9,13 @@
             [dativerf.views.widgets :as widgets]))
 
 (defn- title []
-  [re-com/title
-   :src   (at)
-   :label "Application Settings"
-   :level :level2])
+  (let [old-id @(re-frame/subscribe [::subs/old])
+        olds @(re-frame/subscribe [::subs/olds])
+        old-name (db/old-name {:old old-id :olds olds})]
+    [re-com/title
+     :src   (at)
+     :label (str old-name " Settings")
+     :level :level2]))
 
 (def input-validation-rows
   [{:key :orthographic-validation :type :string}
@@ -28,9 +32,9 @@
    {:key :grammaticalities :type :string}])
 
 (defn- input-validation-subtab []
-  (let [settings @(re-frame/subscribe [::subs/application-settings])]
+  (let [settings @(re-frame/subscribe [::subs/old-settings])]
     [re-com/v-box
-     :src   (at)
+     :src (at)
      :children
      (for [{:as row :keys [key]} input-validation-rows]
        ^{:key key} [widgets/key-value-row
@@ -46,44 +50,58 @@
    {:key :datetime-modified :type :string}])
 
 (defn- server-settings-subtab []
-  (let [settings @(re-frame/subscribe [::subs/application-settings])]
+  (let [settings @(re-frame/subscribe [::subs/old-settings])]
     [re-com/v-box
-     :src   (at)
+     :src (at)
      :children
      (for [{:as row :keys [key]} server-settings-rows]
        ^{:key key} [widgets/key-value-row
                     (utils/kebab->space (name key))
                     (assoc row :value (key settings))])]))
 
-(defmulti settings-subtabs identity)
-(defmethod settings-subtabs :server [] [server-settings-subtab])
-(defmethod settings-subtabs :input-validation [] [input-validation-subtab])
+(defmulti settings-subtabs :handler)
+
+(defmethod settings-subtabs :old-settings []
+  [server-settings-subtab])
+
+(defmethod settings-subtabs :old-settings-input-validation []
+  [input-validation-subtab])
 
 (def ^:private submenu-tabs
-  [{:id :server
-    :label "Server Settings"
-    :authenticated? true}
-   {:id :input-validation
-    :label "Input Validation"
-    :authenticated? true}])
+  [{:id :old-settings
+    :label "General Settings"}
+   {:id :old-settings-input-validation
+    :label "Input Validation"}])
 
-(defn- menu []
+(defn- menu [{:keys [handler]}]
   [re-com/horizontal-tabs
    :src (at)
    :tabs submenu-tabs
-   :model @(re-frame/subscribe [::subs/active-settings-tab])
+   :model handler
    :on-change (fn [tab-id]
-                (re-frame/dispatch [::events/set-settings-active-tab tab-id])
-                (re-frame/dispatch [::events/navigate tab-id]))])
+                (re-frame/dispatch
+                 [::events/navigate
+                  {:handler tab-id
+                   :route-params {:old @(re-frame/subscribe [::subs/old-slug])}}]))])
 
-(defn- settings-tab []
+(defn- settings-tab [route]
   [re-com/v-box
    :src (at)
    :gap "1em"
    :padding "1em"
    :children
    [[title]
-    [menu]
-    (settings-subtabs @(re-frame/subscribe [::subs/active-settings-tab]))]])
+    [menu route]
+    (settings-subtabs route)]])
 
-(defmethod routes/tabs :application-settings [] [settings-tab])
+(defn- old-settings [route]
+  (if @(re-frame/subscribe [::subs/old-settings])
+    [settings-tab route]
+    (do (re-frame/dispatch [::events/fetch-applicationsettings])
+        [re-com/throbber :size :large])))
+
+(defmethod routes/tabs :old-settings [route]
+  (old-settings route))
+
+(defmethod routes/tabs :old-settings-input-validation [route]
+  (old-settings route))


### PR DESCRIPTION
Fixes #14 

## Rationale

I want to be able to view a single form at a unique URL. I also want each view to have a sensible URL path and I want the authenticated OLD to be indicated in that path.


## Changes

- Make routing work for OLD Settings tab

  - General OLD settings and input validation OLD settings are now displayed at
    routes <OLD-SLUG>/settings and <OLD-SLUG>/settings/input-validation,
    respectively.
  - The previously-viewed settings sub-tab state is maintained.
  - OLD application settings are fetched on the initial attempt to render the tab.
  - Rename application-settings ns to old-settings.

- Small routing-related changes

  - Add convenience fn to db ns for getting the slug of the authenticated OLD.
  - Remove unnecessary setting of :forms/previous-route in events ns. Now rely on
    the navigate event for this.
  - Make successful logout use navigation so that the resulting login page
    displays the /login path.

- Add ability to view a single form

  - Clicking on the ID of a single form (e.g., 24314) in browse mode will render a
    view of just that form at a URL path like blaold/forms/24314.

- Make routing work

  - Routing now indicates the authenticated OLD at the top of the path, via a slug
    (e.g., "blaold") that is deduced from its URL.

    - This currently assumes that a globally unique OLD slug can be extracted as
      the final path element of the OLD's URL. This is a shaky assumption.

  - Routing is now used everywhere for form browsing: the path shows the page and
    items-per-page.
  - Navigating to the Forms Brows page returns to the page of forms most recently
    viewed. Such navigation should not trigger a network request.