### PR TITLE
Show authenticated user

### DIFF
--- a/src/dativerf/routes.cljs
+++ b/src/dativerf/routes.cljs
@@ -1,9 +1,8 @@
 (ns dativerf.routes
-  (:require
-   [bidi.bidi :as bidi]
-   [pushy.core :as pushy]
-   [re-frame.core :as re-frame]
-   [dativerf.events :as events]))
+  (:require [bidi.bidi :as bidi]
+            [pushy.core :as pushy]
+            [re-frame.core :as re-frame]
+            [dativerf.events :as events]))
 
 (def routes
   (atom
@@ -22,7 +21,8 @@
           "/logout" :logout
           "/settings"
           {"" :old-settings
-           "/input-validation" :old-settings-input-validation}}}]))
+           "/input-validation" :old-settings-input-validation}
+          "/profile" :profile}}]))
 
 (defmulti tabs :handler)
 

--- a/src/dativerf/views.cljs
+++ b/src/dativerf/views.cljs
@@ -10,7 +10,8 @@
             dativerf.views.old-settings
             dativerf.views.forms
             dativerf.views.home
-            dativerf.views.login))
+            dativerf.views.login
+            dativerf.views.profile))
 
 (defn title []
   (let [user @(re-frame/subscribe [::subs/user])
@@ -35,6 +36,9 @@
     :authenticated? true}
    {:id :old-settings
     :label "Settings"
+    :authenticated? true}
+   {:id :profile
+    :label "Profile"
     :authenticated? true}
    {:id :login
     :label "Login"

--- a/src/dativerf/views/profile.cljs
+++ b/src/dativerf/views/profile.cljs
@@ -1,0 +1,53 @@
+(ns dativerf.views.profile
+  (:require
+    [re-frame.core :as re-frame]
+    [re-com.core :as re-com :refer [at]]
+    [dativerf.styles :as styles]
+    [dativerf.events :as events]
+    [dativerf.routes :as routes]
+    [dativerf.subs :as subs]
+    [dativerf.views.widgets :as widgets]))
+
+(defn user-title []
+      [re-com/title
+       :src (at)
+       :label "Profile"
+       :level :level2])
+
+(def user-rows
+  [{:label "Name"
+    :key :name
+    :getter (fn [{:keys [first-name last-name]}] (str first-name " " last-name))
+    :type :string}
+   {:label "Role"
+    :key :role
+    :getter :role
+    :type :string}
+   {:label "Username"
+    :key :username
+    :getter :username
+    :type :string}
+   {:label "Email"
+    :key :email
+    :getter :email
+    :type :string}])
+
+(defn user-info []
+  (let [user @(re-frame/subscribe [::subs/user])]
+    [re-com/v-box
+     :src (at)
+     :children
+     (for [{:as row :keys [key label getter]} user-rows]
+       ^{:key key} [widgets/key-value-row
+                    label
+                    (assoc row :value (getter user))])]))
+
+(defn profile-tab []
+  [re-com/v-box
+   :src (at)
+   :gap "1em"
+   :padding "1em"
+   :children [[user-title]
+              [user-info]]])
+
+(defmethod routes/tabs :profile [_] [profile-tab])


### PR DESCRIPTION
Fixes #7 

## Rationale

After a user logs in, they should be able to see their profile, which should contain their name, role, email and username.

## Changes

- Show authenticated user in new "Profile" tab.