### PR TITLE
Add export machinery for single forms

### DIFF
--- a/docs/design.rst
+++ b/docs/design.rst
@@ -24,6 +24,25 @@ Ready
 Backlog
 --------------------------------------------------------------------------------
 
+- Improvements to exports.
+
+  - Consider adding an optional :description key to the export maps. This
+    description could be used as a tooltip or as help text to give context on
+    the export.
+  - Should we allow some kind of export configuration? This seems pretty
+    open-ended and therefore difficult to implement generically. Maybe we could
+    just have several different variations on a single export format when we
+    want configuration.
+
+ - Dative-internal state for specific forms should be managed better.
+
+   - The :forms/fetched-at key should not be an attribute of the form. It should
+     be an attribute of
+     ``(get-in db [:old-states (:old db) :forms/view-state form-id])``.
+   - When a form is re-fetched from the server, its Dative-internal state is
+     reset to the default. This should not happen. We should merge the current
+     state on top of the defaults.
+
 - Successful authentication should result in the home page of the authenticated
   OLD being rendered under the home tab.
 - URLs should work on page refresh or on a fresh page. Currently they do not.
@@ -51,6 +70,7 @@ Backlog
 Done
 --------------------------------------------------------------------------------
 
+- DONE. The user can export a single form to various textual formats.
 - DONE. The authenticated OLD's application settings should be displayed at a
   URL path that contains the OLD slug.
 - DONE. When a user is logged out, we route them to the login GUI but the path

--- a/src/dativerf/styles.cljs
+++ b/src/dativerf/styles.cljs
@@ -35,12 +35,35 @@
   {:font-family "'GentiumPlus', serif"
    :font-size "14pt"})
 
+(declare default)
+(defclass default []
+  {:font-family "Segoe UI, Roboto, sans-serif"
+   :font-size "14px"})
+
 (declare form)
 (defclass form []
   {:font-family "'GentiumPlus', serif"
    :font-size "14pt"
-   :width "660px"
-   :cursor "pointer"})
+   :width "660px"})
+
+(declare export-interface)
+(defclass export-interface []
+  {:padding "1em"
+   :margin "1em 0"
+   :border "1px solid #ddd"
+   :border-radius "5px"})
+
+(declare export)
+(defclass export []
+  {:font-family "'GentiumPlus', serif"
+   :margin-top "1em"
+   :margin-bottom "0"
+   :max-height "400px"
+   :font-size "14pt"})
+
+(declare actionable)
+(defclass actionable []
+  {:cursor "pointer"})
 
 (declare widget)
 (defclass widget []

--- a/src/dativerf/subs.cljs
+++ b/src/dativerf/subs.cljs
@@ -96,9 +96,17 @@
                          (filter (fn [{:keys [id]}] (= form-id id)))
                          first)))
 
+(defn- form-view-state [db form-id]
+  (get-in db [:old-states (:old db) :forms/view-state form-id]))
+
 (re-frame/reg-sub ::form-expanded?
                   (fn [db [_ form-id]]
-                    (-> db
-                        (get-in [:old-states (:old db) :forms/view-state form-id
-                                 :expanded?])
-                        boolean)))
+                    (-> db (form-view-state form-id) :expanded?)))
+
+(re-frame/reg-sub ::form-export-interface-visible?
+                  (fn [db [_ form-id]]
+                    (-> db (form-view-state form-id) :export-interface-visible?)))
+
+(re-frame/reg-sub ::form-export-format
+                  (fn [db [_ form-id]]
+                    (-> db (form-view-state form-id) :export-format)))

--- a/src/dativerf/utils.cljs
+++ b/src/dativerf/utils.cljs
@@ -9,15 +9,21 @@
 
 (defn kebab->space [s] (str/replace s #"-" " "))
 
-(defn ->kebab-case-recursive [d]
+(defn modify-form-keywords-recursive [modifier d]
   (walk/postwalk
    (fn [x] (if (keyword? x)
-           (if-let [ns (namespace x)]
-             (keyword (csk/->kebab-case ns)
-                      (csk/->kebab-case (name x)))
-             (csk/->kebab-case x))
-           x))
+             (if-let [ns (namespace x)]
+               (keyword (modifier ns)
+                        (modifier (name x)))
+               (modifier x))
+             x))
    d))
+
+(def ->kebab-case-recursive
+  (partial modify-form-keywords-recursive csk/->kebab-case))
+
+(def ->snake-case-recursive
+  (partial modify-form-keywords-recursive csk/->snake_case_keyword))
 
 (def handler->tab
   {:forms-last-page :forms

--- a/src/dativerf/views/form/exports.cljs
+++ b/src/dativerf/views/form/exports.cljs
@@ -1,0 +1,59 @@
+(ns dativerf.views.form.exports
+  "Define export functions for single forms here. We may eventually want to
+  create sub-namespaces such as dativerf.views.form.exports.latex etc.
+  To create a new export, add a new map to the exports vec with :id, :label and
+  :efn keys. The value of :efn should be an export function. It takes a form and
+  returns a string."
+  (:require [camel-snake-kebab.core :as csk]
+            [dativerf.utils :as utils]
+            [clojure.string :as str]))
+
+;; Plain text export
+;; NOTE: we probably want a better plain-text export than this. This is just an
+;; initial example.
+
+(def plain-text-export-fields
+  [{:label "transcription"
+    :getter (fn [{:keys [transcription grammaticality]}]
+              (str grammaticality transcription))}
+   {:label "morpheme break"
+    :getter :morpheme-break}
+   {:label "morpheme gloss"
+    :getter :morpheme-gloss}
+   {:label "translations"
+    :getter (fn [{:keys [translations]}]
+              (->> translations
+                   (map (fn [{:keys [transcription grammaticality]}]
+                          (str \' grammaticality transcription \')))
+                   (str/join ", ")))}])
+
+(defn plain-text-export [form]
+  (->> plain-text-export-fields
+       (map (fn [{:keys [label getter]}]
+              (str label ": " (getter form))))
+       (str/join "\n")))
+
+;; JSON export
+
+(defn json-export [form]
+  (.stringify js/JSON (clj->js
+                       (-> form
+                           (dissoc :dative/fetched-at)
+                           (update :uuid str)
+                           utils/->snake-case-recursive))
+              nil
+              2))
+
+;; API
+
+(def exports
+  [{:id :plain-text
+    :label "Plain Text"
+    :efn plain-text-export}
+   {:id :json
+    :label "JSON"
+    :efn json-export}])
+
+(defn export [export-id]
+  (first (for [{:as e :keys [id]} exports
+               :when (= export-id id)] e)))


### PR DESCRIPTION
Fixes #26 

## Rationale

We want users to be able to export a single form to various textual formats. For example, at bare minimum, it should be possible to export a form to JSON and at least one ad hoc plaint text format.

## Changes

- Each form now has an export interface with two export format options: "Plain Text" and "JSON".
- It should now be clear how a developer can add additional export formats.
- All forms are now parsed according to the form spec upon initial entry into the system and not, as previously, just prior to display. This means that UUIDs are instances not strings, date strings are converted to objects, etc.