### PR TITLE
Add export machinery for multiple forms

### DIFF
--- a/docs/design.rst
+++ b/docs/design.rst
@@ -24,6 +24,13 @@ Ready
 Backlog
 --------------------------------------------------------------------------------
 
+- Ensure correct round-tripping between OLD REST JSON-encoded schema (for forms,
+  at least) and Dative-internal canonical Clojure form spec.
+
+  - This would be a lot easier if the backend were implemented in Clojure and we
+    could reuse specs. It would be unnecessary if the OLD exposed an (parallel)
+    EDN (or Transit, etc.) API.
+
 - Improvements to exports.
 
   - Consider adding an optional :description key to the export maps. This

--- a/src/dativerf/db.cljs
+++ b/src/dativerf/db.cljs
@@ -30,6 +30,8 @@
    :forms-paginator/last-form 0
    :forms/labels-on? false
    :forms/expanded? false
+   :forms/export-interface-visible? false
+   :forms/export-format :plain-text
    ;; routing state
    :forms/previous-route nil
    :forms/previous-browse-route nil

--- a/src/dativerf/events.cljs
+++ b/src/dativerf/events.cljs
@@ -598,6 +598,11 @@
              [:old-states (:old db) :forms/view-state form-id :export-format]
              export-id)))
 
+(re-frame/reg-event-db
+ ::user-selected-forms-export
+ (fn-traced [db [_ export-id]]
+            (assoc db :forms/export-format export-id)))
+
 (defn- set-forms-expanded [forms-view-state expanded?]
   (->> forms-view-state
        (map (juxt key
@@ -615,6 +620,11 @@
                 (update-in
                  [:old-states (:old db) :forms/view-state]
                  set-forms-expanded false))))
+
+(re-frame/reg-event-db
+ ::user-clicked-export-forms-button
+ (fn-traced [db _]
+            (update db :forms/export-interface-visible? not)))
 
 (re-frame/reg-event-db
  ::user-clicked-expand-all-forms-button

--- a/src/dativerf/subs.cljs
+++ b/src/dativerf/subs.cljs
@@ -96,6 +96,12 @@
                          (filter (fn [{:keys [id]}] (= form-id id)))
                          first)))
 
+(re-frame/reg-sub ::forms-by-ids
+                  (fn [db [_ form-ids]]
+                    (select-keys
+                     (get-in db [:old-states (:old db) :forms])
+                     form-ids)))
+
 (defn- form-view-state [db form-id]
   (get-in db [:old-states (:old db) :forms/view-state form-id]))
 
@@ -110,3 +116,10 @@
 (re-frame/reg-sub ::form-export-format
                   (fn [db [_ form-id]]
                     (-> db (form-view-state form-id) :export-format)))
+
+(re-frame/reg-sub ::forms-export-format
+                  (fn [db _] (:forms/export-format db)))
+
+(re-frame/reg-sub
+ ::forms-export-interface-visible?
+ (fn [db _] (:forms/export-interface-visible? db)))

--- a/src/dativerf/utils.cljs
+++ b/src/dativerf/utils.cljs
@@ -25,6 +25,8 @@
 (def ->snake-case-recursive
   (partial modify-form-keywords-recursive csk/->snake_case_keyword))
 
+(defn ->pretty-json [x] (.stringify js/JSON (clj->js x) nil 2))
+
 (def handler->tab
   {:forms-last-page :forms
    :form-page :forms

--- a/src/dativerf/views/form.cljs
+++ b/src/dativerf/views/form.cljs
@@ -5,6 +5,7 @@
             [dativerf.styles :as styles]
             [dativerf.subs :as subs]
             [dativerf.views.form.exports :as exports]
+            [dativerf.views.widgets :as widgets]
             [re-frame.core :as re-frame]
             [re-com.core :as re-com :refer [at]]))
 
@@ -353,24 +354,6 @@
    [[collapse-button form]
     [export-button form]]])
 
-;; From https://gist.github.com/rotaliator/73daca2dc93c586122a0da57189ece13
-(defn- copy-to-clipboard [val]
-  (let [el (js/document.createElement "textarea")]
-    (set! (.-value el) val)
-    (.appendChild js/document.body el)
-    (.select el)
-    (js/document.execCommand "copy")
-    (.removeChild js/document.body el)))
-
-(defn copy-button [export-string]
-  [re-com/md-circle-icon-button
-   :md-icon-name "zmdi-copy"
-   :size :smaller
-   :tooltip "copy export to clipboard"
-   :on-click (fn [e]
-               (.stopPropagation e)
-               (copy-to-clipboard export-string))])
-
 (defn form-export [export-string]
   [re-com/box
    :class (styles/export)
@@ -388,7 +371,7 @@
        [[re-com/h-box
          :gap "10px"
          :children [[form-export-select form-id]
-                    [copy-button export-string]]]
+                    [widgets/copy-button export-string "form export"]]]
         [form-export export-string]]])))
 
 (defn igt-form-controls [{:as form form-id :uuid}]

--- a/src/dativerf/views/form/exports.cljs
+++ b/src/dativerf/views/form/exports.cljs
@@ -4,8 +4,7 @@
   To create a new export, add a new map to the exports vec with :id, :label and
   :efn keys. The value of :efn should be an export function. It takes a form and
   returns a string."
-  (:require [camel-snake-kebab.core :as csk]
-            [dativerf.utils :as utils]
+  (:require [dativerf.utils :as utils]
             [clojure.string :as str]))
 
 ;; Plain text export
@@ -35,14 +34,14 @@
 
 ;; JSON export
 
+(defn prepare-form-for-jsonification [form]
+  (-> form
+      (dissoc :dative/fetched-at)
+      (update :uuid str)
+      utils/->snake-case-recursive))
+
 (defn json-export [form]
-  (.stringify js/JSON (clj->js
-                       (-> form
-                           (dissoc :dative/fetched-at)
-                           (update :uuid str)
-                           utils/->snake-case-recursive))
-              nil
-              2))
+  (-> form prepare-form-for-jsonification utils/->pretty-json))
 
 ;; API
 

--- a/src/dativerf/views/forms/exports.cljs
+++ b/src/dativerf/views/forms/exports.cljs
@@ -1,0 +1,34 @@
+(ns dativerf.views.forms.exports
+  "Define export functions for multiple forms here. To create a new export, add
+  a new map to the exports vec with :id, :label and :efn keys. The value of :efn
+  should be an export function. It takes a collection of forms and returns a
+  string."
+  (:require [clojure.string :as str]
+            [dativerf.views.form.exports :as form-exports]
+            [dativerf.utils :as utils]))
+
+(defn plain-text-export [forms]
+  (->> forms
+       (map form-exports/plain-text-export)
+       (str/join "\n\n")))
+
+;; JSON export
+
+(defn json-export [forms]
+  (->> forms
+       (map form-exports/prepare-form-for-jsonification)
+       utils/->pretty-json))
+
+;; API
+
+(def exports
+  [{:id :plain-text
+    :label "Plain Text"
+    :efn plain-text-export}
+   {:id :json
+    :label "JSON"
+    :efn json-export}])
+
+(defn export [export-id]
+  (first (for [{:as e :keys [id]} exports
+               :when (= export-id id)] e)))

--- a/src/dativerf/views/widgets.cljs
+++ b/src/dativerf/views/widgets.cljs
@@ -53,3 +53,21 @@
      :label key
      :width "240px"]
     [value-cell value]]])
+
+;; From https://gist.github.com/rotaliator/73daca2dc93c586122a0da57189ece13
+(defn- copy-to-clipboard [val]
+  (let [el (js/document.createElement "textarea")]
+    (set! (.-value el) val)
+    (.appendChild js/document.body el)
+    (.select el)
+    (js/document.execCommand "copy")
+    (.removeChild js/document.body el)))
+
+(defn copy-button [string string-description]
+  [re-com/md-circle-icon-button
+   :md-icon-name "zmdi-copy"
+   :size :smaller
+   :tooltip (str "copy " string-description " to clipboard")
+   :on-click (fn [e]
+               (.stopPropagation e)
+               (copy-to-clipboard string))])


### PR DESCRIPTION
Fixes #36 

## Rationale

We want Dative to be able to export the set of visible forms, using preexisting exporters defined for single forms. We want this to be done in a way such that it is easy for future developers to add new export formats.


## Changes

- The forms browse interface now has a working export interface with the same two preexisting export format options: "Plain Text" and "JSON".
- The multi-forms export interface only exports the current page of forms. It does NOT export the entire set of forms in the OLD. This should probably be done server-side or, if client-side, then only when DativeRF has offline functionality enabled via localStorage or indexedDB.
- It should be clear how one could add additional multi-form exporters.