### PR TITLE
Add ability to delete a form

### DIFF
--- a/src/dativerf/db.cljs
+++ b/src/dativerf/db.cljs
@@ -94,6 +94,7 @@
        :forms/export-format :plain-text
        :forms/new-form-interface-visible? false
        :forms/new-form-secondary-fields-visible? false
+       :forms/form-to-delete nil
        :forms/force-reload? false
        ;; routing state
        :forms/previous-route nil

--- a/src/dativerf/events.cljs
+++ b/src/dativerf/events.cljs
@@ -496,15 +496,18 @@
                              forms-paginator/items-per-page]} :db}
              [_ deleted-form]]
             (let [deleted-form-uuid (-> deleted-form :UUID uuid)
-                  dispatch (if (and (= 1 (count current-page-forms))
-                                    (> current-page 1))
-                             [::navigate
-                              {:handler :forms-page
-                               :route-params
-                               {:old (old-model/slug db)
-                                :items-per-page items-per-page
-                                :page (dec current-page)}}]
-                             [::fetch-forms-page current-page items-per-page])]
+                  dispatch
+                  (cond (= :form-page (-> db :active-route :handler))
+                        [::navigate (:forms/previous-browse-route db)]
+                        (and (= 1 (count current-page-forms))
+                             (> current-page 1))
+                        [::navigate {:handler :forms-page
+                                     :route-params
+                                     {:old (old-model/slug db)
+                                      :items-per-page items-per-page
+                                      :page (dec current-page)}}]
+                        :else
+                        [::fetch-forms-page current-page items-per-page])]
               {:db (-> db
                        (update-in [:old-states (:old db) :forms]
                                   dissoc deleted-form-uuid)

--- a/src/dativerf/events.cljs
+++ b/src/dativerf/events.cljs
@@ -93,10 +93,11 @@
   [response db]
   (let [{:keys [items paginator]} (utils/->kebab-case-recursive response)
         {:keys [page items-per-page count]} paginator
-        current-page page
         last-page (Math/ceil (/ count items-per-page))
-        first-form (- (* current-page items-per-page)
-                      (dec items-per-page))
+        current-page (min last-page page)
+        first-form (min (inc count)
+                        (max 0 (- (* current-page items-per-page)
+                                  (dec items-per-page))))
         last-form (min count (+ first-form (dec items-per-page)))
         fetched-at (.now js/Date)
         forms (forms->uuid-keyed-forms-map items fetched-at)
@@ -672,12 +673,12 @@
               (utils/->kebab-case-recursive forms-new))))
 
 (re-frame/reg-event-db
-  ::formsearches-new-fetched
-  (fn-traced [db [_event formsearches-new]]
-             (assoc-in
-              db
-              [:old-states (:old db) :formsearches-new]
-              (utils/->kebab-case-recursive formsearches-new))))
+ ::formsearches-new-fetched
+ (fn-traced [db [_event formsearches-new]]
+            (assoc-in
+             db
+             [:old-states (:old db) :formsearches-new]
+             (utils/->kebab-case-recursive formsearches-new))))
 
 (re-frame/reg-event-fx
  ::server-deauthenticated
@@ -727,7 +728,7 @@
  ::forms-page-not-fetched
  (fn-traced [db [_ page items-per-page]]
             (warn (str "failed to fetch forms page " page
-                       " with %s items per page " items-per-page))
+                       " with " items-per-page " items per page"))
             db))
 
 (re-frame/reg-event-db

--- a/src/dativerf/subs.cljs
+++ b/src/dativerf/subs.cljs
@@ -189,6 +189,10 @@
  (fn [db _] (:forms/new-form-interface-visible? db)))
 
 (re-frame/reg-sub
+ ::form-to-delete
+ (fn [db _] (:forms/form-to-delete db)))
+
+(re-frame/reg-sub
  ::forms-new-form-secondary-fields-visible?
  (fn [db _] (:forms/new-form-secondary-fields-visible? db)))
 

--- a/src/dativerf/views/form.cljs
+++ b/src/dativerf/views/form.cljs
@@ -12,7 +12,7 @@
 
 ;; Buttons
 
-(defn export-button [{form-id :uuid}]
+(defn export-button [form-id]
   [re-com/md-circle-icon-button
    :md-icon-name "zmdi-download"
    :size :smaller
@@ -23,13 +23,13 @@
                (re-frame/dispatch
                 [::events/user-clicked-export-form-button form-id]))])
 
-(defn collapse-button [{:keys [uuid]}]
+(defn collapse-button [form-id]
   [re-com/md-circle-icon-button
    :md-icon-name "zmdi-chevron-up"
    :size :smaller
    :tooltip "collapse this form"
    :on-click (fn [_] (re-frame/dispatch
-                      [::events/user-clicked-form uuid]))])
+                      [::events/user-clicked-form form-id]))])
 
 (defn form-export-select [form-id]
   [re-com/single-dropdown
@@ -42,6 +42,16 @@
    (fn [export-id]
      (re-frame/dispatch
       [::events/user-selected-form-export form-id export-id]))])
+
+(defn delete-form-button [form-id]
+  [re-com/md-circle-icon-button
+   :md-icon-name "zmdi-delete"
+   :size :smaller
+   :tooltip "delete this form"
+   :on-click
+   (fn [_]
+     (re-frame/dispatch
+      [::events/user-clicked-delete-form-button form-id]))])
 
 ;; End Buttons
 
@@ -357,14 +367,32 @@
         (->> date-str reverse (drop 11) reverse (apply str))
         date-str))))
 
-(defn igt-form-buttons [form]
+(defn header-left [{form-id :uuid}]
   [re-com/h-box
    :src (at)
-   :class (styles/default)
    :gap "5px"
+   :size "auto"
    :children
-   [[collapse-button form]
-    [export-button form]]])
+   [[collapse-button form-id]
+    [export-button form-id]]])
+
+(defn header-right [{form-id :id}]
+  [re-com/h-box
+   :src (at)
+   :gap "5px"
+   :size "auto"
+   :justify :end
+   :children
+   [[delete-form-button form-id]]])
+
+(defn header [form]
+  [re-com/h-box
+   :src (at)
+   :gap "5px"
+   :class (styles/default)
+   :children
+   [[header-left form]
+    [header-right form]]])
 
 (defn form-export [export-string]
   [re-com/box
@@ -391,7 +419,7 @@
     [re-com/v-box
      :class (styles/default)
      :children
-     [[igt-form-buttons form]
+     [[header form]
       [igt-form-export-interface form]]]))
 
 (defn igt-form-secondary

--- a/src/dativerf/views/forms.cljs
+++ b/src/dativerf/views/forms.cljs
@@ -439,11 +439,12 @@
   (let [current-page @(re-frame/subscribe [::subs/forms-current-page])
         page (js/parseInt page)
         form-ids @(re-frame/subscribe [::subs/forms-current-page-forms])
+        forms-count @(re-frame/subscribe [::subs/forms-count])
         forms (filter some?
                       (for [form-id form-ids]
                         @(re-frame/subscribe [::subs/form-by-id form-id])))]
-    (if (and (= page current-page)
-             (= (count form-ids) (count forms)))
+    (if (or (zero? forms-count)
+            (and (= page current-page) (= (count form-ids) (count forms))))
       [forms-tab]
       (do (re-frame/dispatch [::events/fetch-forms-page page items-per-page])
           [re-com/throbber :size :large]))))

--- a/src/dativerf/views/forms.cljs
+++ b/src/dativerf/views/forms.cljs
@@ -431,7 +431,8 @@
    :padding "1em"
    :children
    [[form-navigation]
-    [form/igt-form (:uuid form)]]])
+    [form/igt-form (:uuid form)]
+    [delete-form-modal]]])
 
 (defmethod routes/tabs :forms-page
   [{{:keys [page items-per-page]} :route-params}]

--- a/src/dativerf/views/forms.cljs
+++ b/src/dativerf/views/forms.cljs
@@ -371,6 +371,38 @@
                     [widgets/copy-button export-string "forms export"]]]
         [forms-export export-string]]])))
 
+(defn delete-form-modal []
+  (when-let [form-to-delete @(re-frame/subscribe [::subs/form-to-delete])]
+    [re-com/modal-panel
+     :src (at)
+     :backdrop-color "grey"
+     :backdrop-opacity 0.4
+     :backdrop-on-click (fn [] (re-frame/dispatch
+                                [::events/abort-form-deletion]))
+     :child
+     [re-com/v-box
+      :children
+      [[re-com/alert-box
+        :alert-type :danger
+        :heading (str "Delete form " form-to-delete)
+        :body (str "Are you sure that you want to delete the form with ID "
+                   form-to-delete "?")]
+       [re-com/h-box
+        :gap "10px"
+        :justify :end
+        :children
+        [[re-com/button
+          :label "Cancel"
+          :attr {:auto-focus true}
+          :tooltip "don't actually delete this form"
+          :on-click (fn [] (re-frame/dispatch [::events/abort-form-deletion]))]
+         [re-com/button
+          :label "Ok"
+          :tooltip "go ahead and delete this form"
+          :class "btn-danger"
+          :on-click (fn [_e] (re-frame/dispatch
+                              [::events/delete-form form-to-delete]))]]]]]]))
+
 (defn- forms-tab []
   [re-com/v-box
    :src (at)
@@ -381,7 +413,8 @@
     [forms-settings/interface]
     [forms-new/interface]
     [export-forms-interface]
-    [forms-enumeration]]])
+    [forms-enumeration]
+    [delete-form-modal]]])
 
 (defn- form-navigation []
   [re-com/h-box


### PR DESCRIPTION
Fixes #52. Fixes #50 

## Rationale

We want Dative users to be able to delete forms in their OLDs.

## Changes

- Add delete button on form view
  - It opens a modal dialog for the user to confirm that they want to delete the form.
  - If the user confirms, a `DELETE /forms/<ID>` request is issued. If it succeeds, then we re-fetch the current page's forms or we navigate to the preceding page if the deletion has destroyed the current page.
- Form deletion works on the "view a single form" view.
- A user can delete the last form in an OLD and an empty forms browse page should be displayed, with pagination values that make sense.
- A user can login to an OLD with 0 forms and see an empty forms browse page instead of an infinite spinner.