### PR TITLE
Add ExPex Latex export

### DIFF
--- a/src/dativerf/events.cljs
+++ b/src/dativerf/events.cljs
@@ -66,7 +66,7 @@
        (map (comp
              ;; TODO: fetched-at should be in view state, not in the data itself.
              #(assoc % :dative/fetched-at fetched-at)
-             form-specs/parse-form))
+             form-model/parse-form))
        (map (juxt :uuid identity))
        (into {})))
 

--- a/src/dativerf/exporters/form.cljs
+++ b/src/dativerf/exporters/form.cljs
@@ -4,7 +4,8 @@
   To create a new export, add a new map to the exports vec with :id, :label and
   :efn keys. The value of :efn should be an export function. It takes a form and
   returns a string."
-  (:require [dativerf.utils :as utils]
+  (:require [dativerf.exporters.latex.expex :as expex]
+            [dativerf.utils :as utils]
             [clojure.string :as str]))
 
 ;; Plain text export
@@ -97,15 +98,20 @@
 ;; API
 
 (def exports
-  [{:id :plain-text
-    :label "Plain Text"
-    :efn plain-text-export}
-   {:id :json
-    :label "JSON"
-    :efn json-export}
-   {:id :leipzig-igt
-    :label "Leipzig IGT"
-    :efn leipzig-igt-export}])
+  (sort-by
+   (comp str/lower-case :label)
+   [{:id :plain-text
+     :label "Plain Text"
+     :efn plain-text-export}
+    {:id :json
+     :label "JSON"
+     :efn json-export}
+    {:id :leipzig-igt
+     :label "Leipzig IGT"
+     :efn leipzig-igt-export}
+    {:id :latex-expex
+     :label "LaTeX ExPex"
+     :efn expex/export}]))
 
 (defn export [export-id]
   (first (for [{:as e :keys [id]} exports

--- a/src/dativerf/exporters/forms.cljs
+++ b/src/dativerf/exporters/forms.cljs
@@ -5,16 +5,17 @@
   string."
   (:require [clojure.string :as str]
             [dativerf.exporters.form :as form-exporter]
+            [dativerf.exporters.latex.expex :as expex]
             [dativerf.utils :as utils]))
 
-(defn plain-text-export [forms]
+(defn plain-text-export [forms _]
   (->> forms
        (map form-exporter/plain-text-export)
        (str/join "\n\n")))
 
 ;; JSON export
 
-(defn json-export [forms]
+(defn json-export [forms _]
   (->> forms
        (map form-exporter/prepare-form-for-jsonification)
        utils/->pretty-json))
@@ -23,7 +24,7 @@
 
 ;; I just enclose the collection of <div data-gloss> elements in a generic <div>
 ;; for now. It's not clear to me whether we want to do more here.
-(defn leipzig-igt-export [forms]
+(defn leipzig-igt-export [forms _]
   (str
    "<div>\n\n"
    (->> forms
@@ -34,15 +35,20 @@
 ;; API
 
 (def exports
-  [{:id :plain-text
-    :label "Plain Text"
-    :efn plain-text-export}
-   {:id :json
-    :label "JSON"
-    :efn json-export}
-   {:id :leipzig-igt
-    :label "Leipzig IGT"
-    :efn leipzig-igt-export}])
+  (sort-by
+   (comp str/lower-case :label)
+   [{:id :plain-text
+     :label "Plain Text"
+     :efn plain-text-export}
+    {:id :json
+     :label "JSON"
+     :efn json-export}
+    {:id :leipzig-igt
+     :label "Leipzig IGT"
+     :efn leipzig-igt-export}
+    {:id :latex-expex
+     :label "LaTeX ExPex"
+     :efn expex/export-forms}]))
 
 (defn export [export-id]
   (first (for [{:as e :keys [id]} exports

--- a/src/dativerf/exporters/latex/expex.cljs
+++ b/src/dativerf/exporters/latex/expex.cljs
@@ -1,0 +1,105 @@
+(ns dativerf.exporters.latex.expex
+  "ExPex is a particular library for formatting linguistic IGT examples in
+  LaTeX.
+
+  Rules
+  - there is one A gloss: gla. We favour the transcription value, but use the
+    first in a ranked list. The gla is always the only line that contains the
+    grammaticality, as a prefix.
+  - the rest of the transcription-type fields are B glosses: glb.
+  - the translation line is a free translation: glft. Multiple translations
+    should be separated by linebreaks \\.
+  - Special formatting seems to be required for (some) grammaticality values
+    (or just certain characters) in: the glft the context: for example, * has
+    to be $\\ast{}$."
+  (:require [dativerf.exporters.latex.utils :as latex-u]
+            [dativerf.models.source :as source]
+            [dativerf.models.speaker :as speaker]
+            [dativerf.utils :as utils]
+            [cljs-time.core :as time]
+            [clojure.string :as str]))
+
+(defn trailing-citation
+  "ExPex allows a trailing citation which comes on the same line as the last
+   free translation. We use this to cite the form, preferring speaker and date
+   elicited, falling back to citation of a source. The OLD id is always
+   included."
+  [{:keys [id date-elicited source speaker]}]
+  (str "\\trailingcitation{("
+       (cond speaker
+             (str (speaker/initials speaker)
+                  (when date-elicited
+                    (str ", " (utils/date->human-string date-elicited)))
+                  ", OLD ID: "
+                  id)
+             source
+             (str (source/citation source) ", OLD ID: " id)
+             :else
+             (str "OLD ID: " id))
+       ")}"))
+
+(defn- expex-translations [form]
+  (->> form
+       :translations
+       (filter (fn [v] (some-> v :transcription str/trim not-empty)))
+       (map (fn [{:keys [transcription grammaticality]}]
+              (if (not-empty grammaticality)
+                (str (latex-u/math-asterisk (latex-u/escape-latex grammaticality)) "~`"
+                     (latex-u/escape-latex transcription) "'")
+                (str "`" (latex-u/escape-latex transcription) "'"))))
+       (str/join "\\\\\n    ")))
+
+(defn- glbs [glb-keys form]
+  (->> glb-keys
+       (map (fn [k] (-> form k str/trim latex-u/escape-latex)))
+       (str/join "//\n    \\glb ")))
+
+(defn- ex [body] (str "\\ex\n" body "\\xe\n"))
+(defn- gl [body] (str "  \\begingl\n" body "  \\endgl\n"))
+(defn- gla [body] (str "    \\gla " body "//\n"))
+(defn- glb [body] (str "    \\glb " body "//\n"))
+(defn- glft [body] (str "    \\glft " body "//\n"))
+
+(defn export [form]
+  (let [transcription-keys [:transcription
+                            :narrow-phonetic-transcription
+                            :phonetic-transcription
+                            :morpheme-break]
+        gla-key (->> transcription-keys
+                     (filter (fn [k] (some-> form k str/trim not-empty)))
+                     first)
+        glb-keys (->> (conj transcription-keys :morpheme-gloss)
+                      (filter (fn [k] (and (not= gla-key k)
+                                           (some-> form k str/trim not-empty)))))]
+    (ex
+     (str
+      (gl
+       (str
+        (gla (str (-> form :grammaticality str/trim latex-u/escape-latex)
+                  (-> form gla-key str/trim latex-u/escape-latex)))
+        (when (seq glb-keys) (glb (glbs glb-keys form)))
+        (glft (str (expex-translations form) (trailing-citation form)))))
+      (latex-u/form-medatadata-itemization 2 form)))))
+
+(defn expex-article [title author date body]
+  (str
+   latex-u/xelatex-preamble
+   "\\usepackage{expex}\n"
+   "\\begin{document}\n"
+   "\\title{" title "}\n"
+   "\\author{" author "}\n"
+   "\\date{" date "}\n"
+   "\\maketitle\n"
+   "\n"
+   body
+   "\n"
+   "\\end{document}"))
+
+(defn export-forms [forms {:keys [user]}]
+  (expex-article
+   "DativeRF Expex LaTeX Export"
+   (if user
+     (str (:first-name user) " " (:last-name user))
+     "Unknown Author")
+   (utils/date->human-string (time/now))
+   (str/join "\n" (map export forms))))

--- a/src/dativerf/exporters/latex/utils.cljs
+++ b/src/dativerf/exporters/latex/utils.cljs
@@ -1,0 +1,100 @@
+(ns dativerf.exporters.latex.utils
+  "Utilities for LaTeX exporters."
+  (:require [clojure.string :as str]
+            [dativerf.models.speaker :as speaker]
+            [dativerf.models.source :as source]
+            [dativerf.utils :as utils]))
+
+;; Dealing with the LaTeX implementation
+
+(defn escape-latex
+  "Escape the 10 LaTeX special characters."
+  [string]
+  (-> string
+      (str/replace #"\\" "\\textbackslash")
+      (str/replace #"\{" "\\{")
+      (str/replace #"}" "\\}")
+      (str/replace #"textbackslash" "textbackslash{}")
+      (str/replace #"&" "\\&")
+      (str/replace #"\$" "\\$")
+      (str/replace #"#" "\\#")
+      (str/replace #"_" "\\_")
+      (str/replace #"~" "\\textasciitilde{}")
+      (str/replace #"\^" "\\textasciicircum{}")))
+
+(defn math-asterisk [string]
+  (str/replace string #"\*" "$\\ast{}$"))
+
+;; Reusable functionality for generating LaTeX stuff
+
+(defn indent [n] (apply str (repeat n " ")))
+
+(defn itemize
+  ([items] (itemize 0 items))
+  ([indentation items]
+   (apply str
+          (concat [(str (indent indentation) "\\begin{itemize}\n")]
+                  (for [item items] (str (indent indentation) item))
+                  [(str (indent indentation) "\\end{itemize}\n")]))))
+
+(defn item [item-body] (str "  \\item " item-body "\n"))
+
+(defn- comments [form]
+  (when-let [comments (utils/get-empty-string->nil form :comments)]
+    (str "Comments: " comments)))
+
+(defn- speaker-comments [form]
+  (when-let [speaker-comments (utils/get-empty-string->nil form :speaker-comments)]
+    (str "Speaker comments: " speaker-comments)))
+
+(defn- speaker-item-body [{:keys [speaker]}]
+  (when speaker (str "Speaker: " (speaker/initials speaker))))
+
+(defn- date-elicited-item-body [{:keys [date-elicited]}]
+  (when date-elicited (str "Date elicited: "
+                           (utils/date->human-string date-elicited))))
+
+(defn- source-citation [{:keys [source]}]
+  (and source (str "Source: "(source/citation source))))
+
+(defn- old-id [{:keys [id]}] (str "OLD ID: " id))
+
+(defn form-medatadata-itemization
+  "Return a latex itemization (\\begin{itemize}\\item a\\end{itemize}) for the
+  'core' metada of a form. This is somewhat arbitrary, but it's the stuff we'd
+  expect users to want to list after an IGT representation of a form, say in an
+  article. We return all of the following that are non-empty:
+  - comments
+  - speaker comments
+  - speaker initials and date elicited
+  - source citation
+  - OLD form ID"
+  ([form] (form-medatadata-itemization 0 form))
+  ([indentation form]
+   (or (some->> [(some-> form comments item)
+                 (some-> form speaker-comments item)
+                 (some-> form speaker-item-body item)
+                 (some-> form date-elicited-item-body item)
+                 (some-> form source-citation item)
+                 (some-> form old-id item)]
+                (filter some?)
+                seq
+                (itemize indentation))
+       "")))
+
+(def xelatex-preamble
+  (str
+   "\\documentclass[a4paper,english]{article}\n"
+   "\\usepackage{fixltx2e}\n"
+   "\\usepackage{cmap}\n"
+   "\\usepackage[T1]{fontenc}\n"
+   "\\usepackage{ifthen}\n"
+   "\\usepackage{babel}\n"
+   "\\usepackage{mathptmx}\n"
+   "\\usepackage[scaled=.90]{helvet}\n"
+   "\\usepackage{courier}\n"
+   "\\usepackage{fontspec}\n"
+   "\\defaultfontfeatures{Mapping=tex-text}\n"
+   "\\usepackage{xunicode}\n"
+   "\\usepackage{xltxtra}\n"
+   "\\setmainfont{Charis SIL}\n"))

--- a/src/dativerf/models/form.cljs
+++ b/src/dativerf/models/form.cljs
@@ -46,3 +46,10 @@
                     (get new-form-field-validation-declarations k
                          "The supplied value is invalid."))))
        (into {})))
+
+(defn parse-form [form]
+  (-> form
+      (update :date-elicited utils/date-string?)
+      (update :datetime-entered utils/datetime-string?)
+      (update :datetime-modified utils/datetime-string?)
+      (update :uuid uuid)))

--- a/src/dativerf/models/source.cljs
+++ b/src/dativerf/models/source.cljs
@@ -1,0 +1,178 @@
+(ns dativerf.models.source
+  "Contains constructors for source maps, machinery for accessing source keys
+  (which is non-standard), and helpers to get citation-related strings."
+  (:require [clojure.string :as str]
+            [dativerf.specs.source :as source-spec]
+            [dativerf.utils.bibtex :as bibtex]))
+
+(def default-write-source
+  {:type ""
+   :key ""
+   :file nil
+   :address ""
+   :annote ""
+   :author ""
+   :booktitle ""
+   :chapter ""
+   :crossref "" ;; must be key of an existing source, but only OLD can validate that
+   :edition ""
+   :editor ""
+   :howpublished ""
+   :institution ""
+   :journal ""
+   :key-field ""
+   :month ""
+   :note ""
+   :number ""
+   :organization ""
+   :pages ""
+   :publisher ""
+   :school ""
+   :series ""
+   :title ""
+   :type-field ""
+   :url ""
+   :volume ""
+   :year 0
+   :affiliation ""
+   :abstract ""
+   :contents ""
+   :copyright ""
+   :isbn ""
+   :issn ""
+   :lccn ""
+   :keywords ""
+   :language ""
+   :location ""
+   :mrnumber ""
+   :price ""
+   :size ""})
+
+;; Currently unused, this might be useful for the GUI for source
+;; creation/editing.
+(def bibtex-entry-types
+  {:article [:author :title :journal :year]
+   :book [[:author :editor] :title :publisher :year]
+   :booklet [:title]
+   :conference [:author :title :booktitle :year]
+   :inbook [[:author :editor] :title [:chapter :pages] :publisher :year]
+   :incollection [:author :title :booktitle :publisher :year]
+   :inproceedings [:author :title :booktitle :year]
+   :manual [:title]
+   :mastersthesis [:author :title :school :year]
+   :misc []
+   :phdthesis [:author :title :school :year]
+   :proceedings [:title :year]
+   :techreport [:author :title :institution :year]
+   :unpublished [:author :title :note]})
+
+(defn article
+  ([key author title journal year] (article key author title journal year {}))
+  ([key author title journal year fields]
+   (-> default-write-source
+       (assoc :type "article"
+              :key key
+              :author author
+              :title title
+              :journal journal
+              :year year)
+       (merge fields))))
+
+(defn book
+  ([key author editor title publisher year]
+   (book key author editor title publisher year {}))
+  ([key author editor title publisher year fields]
+   (-> default-write-source
+       (assoc :type "book"
+              :key key
+              :author (or author "")
+              :editor (or editor "")
+              :title title
+              :publisher publisher
+              :year year)
+       (merge fields))))
+
+(defn booklet
+  ([key title] (booklet key title {}))
+  ([key title fields]
+   (-> default-write-source
+       (assoc :type "booklet"
+              :key key
+              :title title)
+       (merge fields))))
+
+(defn conference
+  ([key author title booktitle year]
+   (conference key author title booktitle year {}))
+  ([key author title booktitle year fields]
+   (-> default-write-source
+     (assoc :type "conference"
+            :key key
+            :author author
+            :title title
+            :booktitle booktitle
+            :year year)
+     (merge fields))))
+
+(defn inbook
+  ([key author editor title chapter pages publisher year]
+   (inbook key author editor title chapter pages publisher year {}))
+  ([key author editor title chapter pages publisher year fields]
+   (-> default-write-source
+       (assoc :type "inbook"
+              :key key
+              :author (or author "")
+              :editor (or editor "")
+              :title title
+              :chapter (or chapter "")
+              :pages (or pages "")
+              :publisher publisher
+              :year year)
+       (merge fields))))
+
+;; TODO: complete these as per above, but I'm not sure it's worth the effort.
+(defn incollection [key author title booktitle publisher year])
+(defn inproceedings [key author title booktitle year])
+(defn manual [key title])
+(defn mastersthesis [key author title school year])
+(defn misc [key])
+(defn phdthesis [key author title school year])
+(defn proceedings [key title year])
+(defn techreport [key author title institution year])
+(defn unpublished [key author title note])
+
+
+;; Source getters (!)
+;;
+;; Sources need getters because they can merge with parent sources that they
+;; carry as values. We there fore need special getters for sources (gross).
+;; Alternatively, we could 'normalize' sources (i.e., pre-merge them) upon entry
+;; into Dative. TODO: consider!
+
+(defn- crossref-key
+  "Get key from this source's crossref-source val. NOT recursive. (I'm not sure
+  the OLD allows construction of crossref chains of length three or more.)"
+  [source key]
+  (some-> source :crossref-source key))
+
+(defn s-get [source key] (or (get source key) (crossref-key source key)))
+
+(defn s-keys [source keys] (for [key keys] (s-get source key)))
+
+(defn empty-string->nil [s] (some-> s str/trim not-empty))
+
+(defn author-in-citation-form
+  "Return an author in citation form (string) for the supplied source object.
+  Falls back to the editor in citation form, else the title, else 'no author'."
+  [{:as source}]
+  (let [[author editor title] (s-keys source [:author :editor :title])
+        [author editor title] (map empty-string->nil [author editor title])]
+    (cond author (bibtex/name-in-citation-form author)
+          editor (bibtex/name-in-citation-form editor)
+          title title
+          :else "no author")))
+
+(defn year [source] (or (s-get source :year) -3000))
+
+(defn citation [source]
+  (str (author-in-citation-form source) " (" (year source) ")"))

--- a/src/dativerf/models/source.cljs
+++ b/src/dativerf/models/source.cljs
@@ -1,8 +1,7 @@
 (ns dativerf.models.source
   "Contains constructors for source maps, machinery for accessing source keys
   (which is non-standard), and helpers to get citation-related strings."
-  (:require [clojure.string :as str]
-            [dativerf.specs.source :as source-spec]
+  (:require [dativerf.utils :as utils]
             [dativerf.utils.bibtex :as bibtex]))
 
 (def default-write-source
@@ -131,16 +130,15 @@
        (merge fields))))
 
 ;; TODO: complete these as per above, but I'm not sure it's worth the effort.
-(defn incollection [key author title booktitle publisher year])
-(defn inproceedings [key author title booktitle year])
-(defn manual [key title])
-(defn mastersthesis [key author title school year])
-(defn misc [key])
-(defn phdthesis [key author title school year])
-(defn proceedings [key title year])
-(defn techreport [key author title institution year])
-(defn unpublished [key author title note])
-
+;; (defn incollection [key author title booktitle publisher year])
+;; (defn inproceedings [key author title booktitle year])
+;; (defn manual [key title])
+;; (defn mastersthesis [key author title school year])
+;; (defn misc [key])
+;; (defn phdthesis [key author title school year])
+;; (defn proceedings [key title year])
+;; (defn techreport [key author title institution year])
+;; (defn unpublished [key author title note])
 
 ;; Source getters (!)
 ;;
@@ -159,14 +157,12 @@
 
 (defn s-keys [source keys] (for [key keys] (s-get source key)))
 
-(defn empty-string->nil [s] (some-> s str/trim not-empty))
-
 (defn author-in-citation-form
   "Return an author in citation form (string) for the supplied source object.
   Falls back to the editor in citation form, else the title, else 'no author'."
   [{:as source}]
   (let [[author editor title] (s-keys source [:author :editor :title])
-        [author editor title] (map empty-string->nil [author editor title])]
+        [author editor title] (map utils/empty-string->nil [author editor title])]
     (cond author (bibtex/name-in-citation-form author)
           editor (bibtex/name-in-citation-form editor)
           title title

--- a/src/dativerf/models/speaker.cljs
+++ b/src/dativerf/models/speaker.cljs
@@ -1,0 +1,6 @@
+(ns dativerf.models.speaker
+  (:require [clojure.string :as str]))
+
+(defn initials [speaker]
+  (str (-> speaker :first-name first str/upper-case)
+       (-> speaker :last-name first str/upper-case)))

--- a/src/dativerf/specs/common.cljs
+++ b/src/dativerf/specs/common.cljs
@@ -1,0 +1,9 @@
+(ns dativerf.specs.common
+  (:require [clojure.spec.alpha :as s]
+            [dativerf.utils :as utils]))
+
+(s/def ::id pos-int?)
+(s/def ::date-string utils/date-string?)
+(s/def ::datetime-string utils/datetime-string?)
+
+(defn string-max-len? [len string] (and (string? string) (<= (count string) len)))

--- a/src/dativerf/specs/file.cljs
+++ b/src/dativerf/specs/file.cljs
@@ -1,0 +1,37 @@
+(ns dativerf.specs.file
+  (:require [clojure.spec.alpha :as s]
+            [dativerf.specs.common :as common]))
+
+;; TODO: there are three distinct types of files, each with its own spec
+
+;; TODO: use the following set of valid MIME types to spec ::mime-type?
+(def allowed-file-mime-types
+  #{"application/pdf"
+    "image/gif"
+    "image/jpeg"
+    "image/png"
+    "audio/mpeg"
+    "audio/ogg"
+    "audio/wav"
+    "audio/x-wav"
+    "video/mpeg"
+    "video/mp4"
+    "video/ogg"
+    "video/quicktime"
+    "video/x-ms-wmv"})
+
+(s/def ::id ::common/id)
+(s/def ::name (partial common/string-max-len? 255))
+(s/def ::filename (partial common/string-max-len? 255))
+(s/def ::mime-type (partial common/string-max-len? 255))
+(s/def ::size nat-int?)
+(s/def ::url (partial common/string-max-len? 255))
+(s/def ::lossy-filename (partial common/string-max-len? 255))
+(s/def ::mini-file (s/keys :req-un [::id
+                                    ::name
+                                    ::filename
+                                    ::mime-type
+                                    ::size
+                                    ::url
+                                    ::lossy-filename]))
+(s/def ::mini-files (s/coll-of ::mini-file))

--- a/src/dativerf/specs/form.cljs
+++ b/src/dativerf/specs/form.cljs
@@ -3,7 +3,6 @@
             [clojure.spec.gen.alpha :as gen]
             [clojure.test.check.generators]
             [clojure.string :as str]
-            [cljs-time.format :as timef]
             [dativerf.db :as db]
             [dativerf.specs.common :as common]
             [dativerf.specs.file :as file]

--- a/src/dativerf/specs/form.cljs
+++ b/src/dativerf/specs/form.cljs
@@ -5,6 +5,9 @@
             [clojure.string :as str]
             [cljs-time.format :as timef]
             [dativerf.db :as db]
+            [dativerf.specs.common :as common]
+            [dativerf.specs.file :as file]
+            [dativerf.specs.source :as source]
             [dativerf.utils :as utils]
             [goog.string :as gstring]
             [goog.string.format]))
@@ -12,37 +15,7 @@
 ;; TODO: this ns is called form but there are specs for all types of resources
 ;; in here.
 
-;; General specs and specs that should be moved to their own namespaces
-
-(s/def :int/id pos-int?)
-
-(defn parse-date-string [x]
-  (try (timef/parse (timef/formatters :date) x)
-       (catch js/Error _)))
-
-(defn date-string? [^string x]
-  (and (string? x)
-       (parse-date-string x)))
-
-(s/def ::date-string date-string?)
-
-(defn parse-datetime-string
-  "Parse a datetime string like 2022-02-23T18:27:49.628337. To do this, we must
-  remove the last 3 digits, reducing the microsecond precision to millisecond
-  precision."
-  [x]
-  (try (timef/parse
-        (timef/formatters :date-hour-minute-second-ms)
-        (str/replace x #"\.(\d{3})\d{3}$" ".$1"))
-       (catch js/Error _)))
-
-(defn datetime-string? [^string x]
-  (and (string? x)
-       (parse-datetime-string x)))
-
-(s/def ::datetime-string datetime-string?)
-
-(s/def :user/id :int/id)
+(s/def :user/id ::common/id)
 (s/def :user/first-name string?)
 (s/def :user/last-name string?)
 (s/def :user/role #{"administrator" "contributor" "viewer"})
@@ -51,75 +24,23 @@
                                :user/last-name
                                :user/role]))
 
-(s/def :tag/id :int/id)
+(s/def :tag/id ::common/id)
 (s/def :tag/name string?)
 (s/def :tag/description string?)
-(s/def :tag/datetime-modified ::datetime-string)
+(s/def :tag/datetime-modified ::common/datetime-string)
 (s/def ::tag (s/keys :req-un [:tag/id
                               :tag/name
                               :tag/description
                               :tag/datetime-modified]))
 (s/def ::tags (s/coll-of ::tag))
 
-(s/def :syntactic-category/id :int/id)
+(s/def :syntactic-category/id ::common/id)
 (s/def :syntactic-category/name string?)
 (s/def ::syntactic-category (s/keys :req-un [:syntactic-category/id
                                              :syntactic-category/name]))
 (s/def ::syntactic-categories (s/coll-of ::syntactic-category))
 
-(s/def :source/id :int/id) ;; 3,
-(s/def :source/institution string?) ;; "",
-(s/def :source/publisher string?) ;; "Toronto: University of Toronto Press",
-(s/def :source/key string?) ;; "frantz1995",
-(s/def :source/school string?) ;; "",
-(s/def :source/type string?) ;; "book",
-(s/def :source/journal string?) ;; "",
-(s/def :source/title string?) ;; "Blackfoot Dictionary of Stems, Roots and Affixes",
-(s/def :source/pages string?) ;; "",
-(s/def :source/note string?) ;; "",
-(s/def :source/author string?) ;; "Frantz, D G and Russell, N J",
-(s/def :source/chapter string?) ;; "",
-(s/def :source/year int?) ;; 1995,
-(s/def :source/crossref string?) ;; "",
-(s/def :source/editor string?) ;; "",
-(s/def :source/booktitle string?) ;; ""}
-(s/def ::source (s/keys :req-un
-                        [:source/institution
-                         :source/publisher
-                         :source/key
-                         :source/school
-                         :source/type
-                         :source/journal
-                         :source/title
-                         :source/pages
-                         :source/note
-                         :source/author
-                         :source/chapter
-                         :source/year
-                         :source/crossref
-                         :source/id
-                         :source/editor
-                         :source/booktitle]))
-
-(s/def :file/id :int/id)
-(s/def :file/name string?)
-(s/def :file/filename string?)
-(s/def :file/mime-type string?) ;; TODO: closed set of types
-(s/def :file/size nat-int?)
-(s/def :file/url (s/nilable string?))
-(s/def :file/lossy-filename (s/nilable string?))
-
-;; TODO: there are three distinct types of files, each with its own spec
-(s/def ::file (s/keys :req-un [:file/id
-                               :file/name
-                               :file/filename
-                               :file/mime-type
-                               :file/size
-                               :file/url
-                               :file/lossy-filename]))
-(s/def ::files (s/coll-of ::file))
-
-(s/def :elicitation-method/id :int/id)
+(s/def :elicitation-method/id ::common/id)
 (s/def :elicitation-method/name string?)
 (s/def ::elicitation-method (s/keys :req-un [:elicitation-method/id
                                              :elicitation-method/name]))
@@ -131,7 +52,7 @@
                 x)))
 (s/def ::uuid-string uuid-string?)
 
-(s/def :speaker/id :int/id)
+(s/def :speaker/id ::common/id)
 (s/def :speaker/first-name string?)
 (s/def :speaker/last-name string?)
 (s/def :speaker/dialect string?)
@@ -141,7 +62,7 @@
                                   :speaker/dialect]))
 (s/def ::speakers (s/coll-of ::speaker))
 
-(s/def :translation/id :int/id)
+(s/def :translation/id ::common/id)
 (s/def :translation/transcription string?)
 (s/def :translation/grammaticality string?)
 (s/def ::translation (s/keys :req-un [:translation/id
@@ -152,12 +73,12 @@
 ;; Form spec
 
 (s/def :form/tags ::tags)
-(s/def :form/date-elicited (s/nilable ::date-string))
+(s/def :form/date-elicited (s/nilable ::common/date-string))
 (s/def :form/narrow-phonetic-transcription string?)
 (s/def :form/enterer (s/nilable ::user))
 ;; TODO: datetime-entered should not be nilable, but OLDs do have forms with a
 ;; nil value here...
-(s/def :form/datetime-entered (s/nilable ::datetime-string))
+(s/def :form/datetime-entered (s/nilable ::common/datetime-string))
 (s/def :form/verifier (s/nilable ::user))
 (s/def :form/break-gloss-category string?)
 (s/def :form/modifier (s/nilable ::user))
@@ -167,17 +88,17 @@
 (s/def :form/morpheme-gloss-ids (s/nilable (s/coll-of any?)))
 (s/def :form/semantics string?)
 (s/def :form/comments string?)
-(s/def :form/source (s/nilable ::source))
+(s/def :form/source (s/nilable ::source/mini-source))
 (s/def :form/syntactic-category-string string?)
 ;; TODO: dynamic validation based on app settings
 (s/def :form/grammaticality string?)
 (s/def :form/status string?) ;; TODO: closed class?
 (s/def :form/syntax string?)
-(s/def :form/id :int/id)
+(s/def :form/id ::common/id)
 (s/def :form/morpheme-gloss (s/nilable string?))
-(s/def :form/files ::files)
+(s/def :form/files ::file/mini-files)
 (s/def :form/elicitation-method (s/nilable ::elicitation-method))
-(s/def :form/datetime-modified ::datetime-string)
+(s/def :form/datetime-modified ::common/datetime-string)
 (s/def :form/uuid ::uuid-string)
 (s/def :form/morpheme-break string?)
 (s/def :form/speaker (s/nilable ::speaker))
@@ -223,13 +144,6 @@
 
 (defn form-explain-data [form]
   (s/explain-data ::form form))
-
-(defn parse-form [form]
-  (-> form
-      (update :date-elicited date-string?)
-      (update :datetime-entered datetime-string?)
-      (update :datetime-modified datetime-string?)
-      (update :uuid uuid)))
 
 ;; Write Form
 ;;
@@ -292,15 +206,15 @@
 (s/def :write-form/syntax (s/and string? (partial max-length 1023)))
 (s/def :write-form/semantics (s/and string? (partial max-length 1023)))
 (s/def :write-form/status #{"tested" "requires testing"})
-(s/def :write-form/elicitation-method (s/nilable :int/id))
-(s/def :write-form/syntactic-category (s/nilable :int/id))
-(s/def :write-form/speaker (s/nilable :int/id))
-(s/def :write-form/elicitor (s/nilable :int/id))
-(s/def :write-form/verifier (s/nilable :int/id))
-(s/def :write-form/source (s/nilable :int/id))
-(s/def :write-form/tag :int/id)
+(s/def :write-form/elicitation-method (s/nilable ::common/id))
+(s/def :write-form/syntactic-category (s/nilable ::common/id))
+(s/def :write-form/speaker (s/nilable ::common/id))
+(s/def :write-form/elicitor (s/nilable ::common/id))
+(s/def :write-form/verifier (s/nilable ::common/id))
+(s/def :write-form/source (s/nilable ::common/id))
+(s/def :write-form/tag ::common/id)
 (s/def :write-form/tags (s/coll-of :write-form/tag :distinct true))
-(s/def :write-form/file :int/id)
+(s/def :write-form/file ::common/id)
 (s/def :write-form/files (s/coll-of :write-form/file :distinct true))
 
 (defn- one-non-empty-transcription-type-value [form]

--- a/src/dativerf/specs/source.cljs
+++ b/src/dativerf/specs/source.cljs
@@ -1,0 +1,324 @@
+(ns dativerf.specs.source
+  (:require [clojure.spec.alpha :as s]
+            [dativerf.specs.common :as common]
+            [dativerf.specs.file :as file]))
+
+;; All types of sources (both "mini" and regular) should have the following keys.
+(s/def ::id ::common/id) ;; 3,
+(s/def ::crossref (partial common/string-max-len? 1000))
+(s/def ::crossref-source (s/nilable ::mini-source))
+(s/def ::crossref-source-id (s/nilable ::common/id))
+(s/def ::type #{"article"
+                "book"
+                "booklet"
+                "conference"
+                "inbook"
+                "incollection"
+                "inproceedings"
+                "manual"
+                "mastersthesis"
+                "misc"
+                "phdthesis"
+                "proceedings"
+                "techreport"
+                "unpublished"})
+(s/def ::key (s/and string?
+                    (partial
+                     re-find
+                     #"^[0-9a-zA-Z!\"'#\$%&\(\)\^\*+\./:;<=>\?@\[\]\{\}\\_`\|~-]{1,1000}$")))
+(s/def ::journal (partial common/string-max-len? 255))
+(s/def ::editor (partial common/string-max-len? 255))
+(s/def ::chapter (partial common/string-max-len? 255))
+(s/def ::pages (partial common/string-max-len? 100))
+(s/def ::publisher (partial common/string-max-len? 255))
+(s/def ::booktitle (partial common/string-max-len? 255))
+(s/def ::school (partial common/string-max-len? 255))
+(s/def ::institution (partial common/string-max-len? 255))
+(s/def ::year int?)
+(s/def ::author (partial common/string-max-len? 255))
+(s/def ::title (partial common/string-max-len? 255))
+(s/def ::note (partial common/string-max-len? 1000))
+
+;; Certain sub-types of source (e.g., book, or article) require non-empty  keys.
+(s/def :not-empty/author (s/and ::author not-empty))
+(s/def :not-empty/editor (s/and ::editor not-empty))
+(s/def :not-empty/title (s/and ::title not-empty))
+(s/def :not-empty/journal (s/and ::journal not-empty))
+(s/def :not-empty/publisher (s/and ::publisher not-empty))
+(s/def :not-empty/booktitle (s/and ::booktitle not-empty))
+(s/def :not-empty/chapter (s/and ::chapter not-empty))
+(s/def :not-empty/pages (s/and ::pages not-empty))
+(s/def :not-empty/school (s/and ::school not-empty))
+(s/def :not-empty/institution (s/and ::institution not-empty))
+(s/def :not-empty/note (s/and ::note not-empty))
+
+;; OLD-specific keys
+(s/def ::file-id (s/nilable ::common/id))
+(s/def ::file (s/nilable ::file/mini-file))
+(s/def ::datetime-modified ::common/datetime-string)
+
+;; Optional BibTeX keys
+(s/def ::address (partial common/string-max-len? 1000))
+(s/def ::annote string?)
+(s/def ::edition (partial common/string-max-len? 255))
+(s/def ::howpublished (partial common/string-max-len? 255))
+(s/def ::key-field (partial common/string-max-len? 255))
+(s/def ::month (partial common/string-max-len? 100))
+(s/def ::number (partial common/string-max-len? 100))
+(s/def ::organization (partial common/string-max-len? 255))
+(s/def ::series (partial common/string-max-len? 255))
+(s/def ::type-field (partial common/string-max-len? 255))
+(s/def ::url (partial common/string-max-len? 1000))
+(s/def ::volume (partial common/string-max-len? 100))
+
+;; Optional Non-standard BibTeX keys
+(s/def ::abstract (partial common/string-max-len? 1000))
+(s/def ::affiliation (partial common/string-max-len? 255))
+(s/def ::contents (partial common/string-max-len? 255))
+(s/def ::copyright (partial common/string-max-len? 255))
+(s/def ::keywords (partial common/string-max-len? 255))
+(s/def ::language (partial common/string-max-len? 255))
+(s/def ::location (partial common/string-max-len? 255))
+(s/def ::size (partial common/string-max-len? 255))
+(s/def ::price (partial common/string-max-len? 100))
+(s/def ::mrnumber (partial common/string-max-len? 25))
+(s/def ::isbn (partial common/string-max-len? 20))
+(s/def ::issn (partial common/string-max-len? 20))
+(s/def ::lccn (partial common/string-max-len? 20))
+
+;; The ::mini-source is a read source. It is what we receive from the OLD when a
+;; source is associated to another entity, e.g., a form or a collection. It has
+;; a subset of the keys of a standard/regular read ::source.
+(s/def ::mini-source (s/keys :req-un
+                             [::id
+                              ::crossref
+                              ::crossref-source
+                              ::type
+                              ::key
+                              ::journal
+                              ::editor
+                              ::chapter
+                              ::pages
+                              ::publisher
+                              ::booktitle
+                              ::school
+                              ::institution
+                              ::year
+                              ::author
+                              ::title
+                              ::note]))
+
+;; TODO: there is a lot of repetition between ::mini-source, ::source and
+;; ::write-source. We could consider being clever and using s/merge to DRY this
+;; up.
+
+(s/def ::source (s/keys :req-un
+                        ;; core keys
+                        [::id
+                         ::crossref
+                         ::crossref-source
+                         ::crossref-source-id
+                         ::type
+                         ::key
+                         ::journal
+                         ::editor
+                         ::chapter
+                         ::pages
+                         ::publisher
+                         ::booktitle
+                         ::school
+                         ::institution
+                         ::year
+                         ::author
+                         ::title
+                         ::note
+                         ;; OLD-specific keys
+                         ::file-id
+                         ::file
+                         ::datetime-modified
+                         ;; Optional keys
+                         ::address
+                         ::annote
+                         ::edition
+                         ::howpublished
+                         ::key-field
+                         ::month
+                         ::number
+                         ::organization
+                         ::series
+                         ::type-field
+                         ::url
+                         ::volume
+                         ;; Non-standard keys
+                         ::abstract
+                         ::affiliation
+                         ::contents
+                         ::copyright
+                         ::keywords
+                         ::language
+                         ::location
+                         ::size
+                         ::price
+                         ::mrnumber
+                         ::isbn
+                         ::issn
+                         ::lccn]))
+
+;; Write Source
+;;
+;; The spec ::write-source defines what a new Source must look like when making
+;; a POST request to an OLD's /forms endpoint.
+;;
+;; WARNING: validation via crossref is NOT implemented. Basically, BibTeX entry
+;; types (and therefore OLD sources) can satisfy requirements on keys by falling
+;; back to those values on a parent, said parent being referenced in the child's
+;; :crossref key using the parent's :key key.
+
+(s/def :write-source/file (s/nilable ::common/id))
+
+(s/def ::write-source-common
+  (s/keys :req-un [::type
+                   ::key
+                   :write-source/file
+                   ::address
+                   ::annote
+                   ::author
+                   ::booktitle
+                   ::chapter
+                   ::crossref
+                   ::edition
+                   ::editor
+                   ::howpublished
+                   ::institution
+                   ::journal
+                   ::key-field
+                   ::month
+                   ::note
+                   ::number
+                   ::organization
+                   ::pages
+                   ::publisher
+                   ::school
+                   ::series
+                   ::title
+                   ::type-field
+                   ::url
+                   ::volume
+                   ::year
+                   ;; non-standard
+                   ::affiliation
+                   ::abstract
+                   ::contents
+                   ::copyright
+                   ::isbn
+                   ::issn
+                   ::lccn
+                   ::keywords
+                   ::language
+                   ::location
+                   ::mrnumber
+                   ::price
+                   ::size]))
+
+;; Use a multi-spec to define write-source
+
+(defmulti write-source :type)
+
+(defmethod write-source "article" [_]
+  (s/merge ::write-source-common
+           (s/keys :req-un [:not-empty/author
+                            :not-empty/title
+                            :not-empty/journal])))
+
+(defmethod write-source "book" [_]
+  (s/merge ::write-source-common
+           (s/or :author-book (s/keys :req-un [:not-empty/author
+                                               :not-empty/title
+                                               :not-empty/publisher])
+                 :editor-book (s/keys :req-un [:not-empty/editor
+                                               :not-empty/title
+                                               :not-empty/publisher]))))
+
+(defmethod write-source "booklet" [_]
+  (s/merge ::write-source-common
+           (s/keys :req-un [:not-empty/title])))
+
+(defmethod write-source "manual" [_]
+  (s/merge ::write-source-common
+           (s/keys :req-un [:not-empty/title])))
+
+(defmethod write-source "proceedings" [_]
+  (s/merge ::write-source-common
+           (s/keys :req-un [:not-empty/title])))
+
+(defmethod write-source "conference" [_]
+  (s/merge ::write-source-common
+           (s/keys :req-un [:not-empty/author
+                            :not-empty/title
+                            :not-empty/booktitle])))
+
+(defmethod write-source "inproceedings" [_]
+  (s/merge ::write-source-common
+           (s/keys :req-un [:not-empty/author
+                            :not-empty/title
+                            :not-empty/booktitle])))
+
+(defmethod write-source "inbook" [_]
+  (s/merge ::write-source-common
+           (s/or :author-chapter-inbook (s/keys :req-un [:not-empty/author
+                                                         :not-empty/title
+                                                         :not-empty/chapter
+                                                         :not-empty/publisher])
+                 :editor-chapter-inbook (s/keys :req-un [:not-empty/editor
+                                                         :not-empty/title
+                                                         :not-empty/chapter
+                                                         :not-empty/publisher])
+                 :author-pages-inbook (s/keys :req-un [:not-empty/author
+                                                       :not-empty/title
+                                                       :not-empty/pages
+                                                       :not-empty/publisher])
+                 :editor-pages-inbook (s/keys :req-un [:not-empty/editor
+                                                       :not-empty/title
+                                                       :not-empty/pages
+                                                       :not-empty/publisher]))))
+
+(defmethod write-source "incollection" [_]
+  (s/merge ::write-source-common
+           (s/keys :req-un [:not-empty/author
+                            :not-empty/title
+                            :not-empty/booktitle
+                            :not-empty/publisher])))
+
+(defmethod write-source "phdthesis" [_]
+  (s/merge ::write-source-common
+           (s/keys :req-un [:not-empty/author
+                            :not-empty/title
+                            :not-empty/school])))
+
+(defmethod write-source "mastersthesis" [_]
+  (s/merge ::write-source-common
+           (s/keys :req-un [:not-empty/author
+                            :not-empty/title
+                            :not-empty/school])))
+
+(defmethod write-source "techreport" [_]
+  (s/merge ::write-source-common
+           (s/keys :req-un [:not-empty/author
+                            :not-empty/title
+                            :not-empty/institution])))
+
+(defmethod write-source "unpublished" [_]
+  (s/merge ::write-source-common
+           (s/keys :req-un [:not-empty/author
+                            :not-empty/title
+                            :not-empty/note])))
+
+(defmethod write-source "misc" [_] ::write-source-common)
+
+(s/def ::write-source (s/multi-spec write-source ::type))
+
+(defn write-source-valid? [write-source]
+  (s/valid? ::write-source write-source))
+
+(defn write-source-explain-data [write-source]
+  (s/explain-data ::write-source write-source))

--- a/src/dativerf/utils.cljs
+++ b/src/dativerf/utils.cljs
@@ -92,3 +92,25 @@
       (if (= " 00:00:00 Z" time-sfx)
         (->> date-str reverse (drop 11) reverse (apply str))
         date-str))))
+
+(defn parse-date-string [x]
+  (try (timef/parse (timef/formatters :date) x)
+       (catch js/Error _)))
+
+(defn date-string? [^string x]
+  (and (string? x)
+       (parse-date-string x)))
+
+(defn parse-datetime-string
+  "Parse a datetime string like 2022-02-23T18:27:49.628337. To do this, we must
+  remove the last 3 digits, reducing the microsecond precision to millisecond
+  precision."
+  [x]
+  (try (timef/parse
+        (timef/formatters :date-hour-minute-second-ms)
+        (str/replace x #"\.(\d{3})\d{3}$" ".$1"))
+       (catch js/Error _)))
+
+(defn datetime-string? [^string x]
+  (and (string? x)
+       (parse-datetime-string x)))

--- a/src/dativerf/utils.cljs
+++ b/src/dativerf/utils.cljs
@@ -89,7 +89,8 @@
   (when date
     (let [date-str (datetime->human-string date)
           time-sfx (->> date-str reverse (take 11) reverse (apply str))]
-      (if (= " 00:00:00 Z" time-sfx)
+      (if (and (= " " (first time-sfx))
+               (= "Z" (last time-sfx)))
         (->> date-str reverse (drop 11) reverse (apply str))
         date-str))))
 
@@ -114,3 +115,7 @@
 (defn datetime-string? [^string x]
   (and (string? x)
        (parse-datetime-string x)))
+
+(defn empty-string->nil [s] (some-> s str/trim not-empty))
+
+(defn get-empty-string->nil [m k] (some-> m k empty-string->nil))

--- a/src/dativerf/utils.cljs
+++ b/src/dativerf/utils.cljs
@@ -1,6 +1,7 @@
 (ns dativerf.utils
   (:require [camel-snake-kebab.core :as csk]
             [cljs.pprint :as pprint]
+            [cljs-time.format :as timef]
             [clojure.string :as str]
             [clojure.walk :as walk]
             [goog.string :as gstring]
@@ -75,3 +76,19 @@
    (gstring/format "%02d" (.getDate dt))
    "/"
    (gstring/format "%02d" (.getYear dt))))
+
+;; Format returned is 'Fri, 22 Jan 2016 21:43:54 Z'
+;; Probably want something different eventually.
+(defn datetime->human-string [datetime]
+  (timef/unparse (timef/formatters :rfc822) datetime))
+
+;; WARNING: hacky
+;; Format returned is 'Fri, 22 Jan 2016'
+;; Probably want something different eventually.
+(defn date->human-string [date]
+  (when date
+    (let [date-str (datetime->human-string date)
+          time-sfx (->> date-str reverse (take 11) reverse (apply str))]
+      (if (= " 00:00:00 Z" time-sfx)
+        (->> date-str reverse (drop 11) reverse (apply str))
+        date-str))))

--- a/src/dativerf/utils/bibtex.cljs
+++ b/src/dativerf/utils/bibtex.cljs
@@ -1,6 +1,14 @@
 (ns dativerf.utils.bibtex
-  "Utils for handling BibTeX entities. These are related to OLD source entities,
-  since sources are essentially BibTeX entries."
+  "Utils for handling BibTeX entities. These are the foundation for OLD source
+  entities, since sources are essentially BibTeX entries.
+
+  GUIDANCE:
+  - Functionality should go here if it is about BibTeX-specific things, such as
+    parsing name strings correctly.
+  - Functionality should go in the Sources model ns if it is about
+    implementation details of how the OLD models BibTeX entities, e.g.,
+    accessing attributes via crossref links where the cross-referenced source is
+    pre-hydrated (by the OLD) on the crossref-source key."
   (:require [clojure.string :as str]))
 
 (defn- clean-token [token] (str/replace token #"^\{(.*)\}$" "$1"))
@@ -91,19 +99,3 @@
 (defn name-in-citation-form [name]
   (try (last-names (parse-bibtex-name name))
        (catch js/Error _ name)))
-
-(defn author
-  "Return an author for supplied source object. We return the author in
-  citation form if there is an author; otherwise we return the editor in
-  citation form or the title or 'no author'."
-  [{:keys [author editor title]}]
-  (let [prep (fn [x] (some-> x str/trim not-empty))
-        [author editor title] (map prep [author editor title])]
-    (cond author (name-in-citation-form author)
-          editor (name-in-citation-form editor)
-          title title
-          :else "no author")))
-
-;; TODO: it smells that year is int according to the spec but the not found
-;; value is a string.
-(defn year [source] (or (:year source) "no year"))

--- a/src/dativerf/utils/bibtex.cljs
+++ b/src/dativerf/utils/bibtex.cljs
@@ -1,0 +1,109 @@
+(ns dativerf.utils.bibtex
+  "Utils for handling BibTeX entities. These are related to OLD source entities,
+  since sources are essentially BibTeX entries."
+  (:require [clojure.string :as str]))
+
+(defn- clean-token [token] (str/replace token #"^\{(.*)\}$" "$1"))
+
+(def tokenizer-pattern
+  (re-pattern
+   (str
+    ;; a brace-enclosed single token; a sequence of non-braces between braces
+    "\\{[^\\{\\}]+\\}|"
+    ;; a sequence of non-spaces and non-commas
+    "[^ ,]+|"
+    ;; comma
+    ",")))
+
+(defn- last-names
+  "Given a parsed BibTeX name (an array of name maps), return a string of
+  conjoined last names, e.g., 'Smith, Yang, and Moore'."
+  [parsed-name]
+  (let [lnames (map (fn [{:keys [last]}] (str/join " " last)) parsed-name)]
+    (if (= 1 (count lnames))
+      (first lnames)
+      (str (str/join ", " (butlast lnames)) " and " (last lnames)))))
+
+;; TODO: this will fail for "von" parts that contain non-initial capital letters.
+;; However, a definition like the following has its own problems:
+;; (defn- von? [token] (= (first token) (str/lower-case (first token))))
+;; A regex may be needed.
+(defn- von? [token] (= token (str/lower-case token)))
+
+(defn- first-von-last [tokens]
+  (reduce-kv
+   (fn [agg idx token]
+     (update agg
+             (cond (zero? idx) :first
+                   (= (dec (count tokens)) idx) :last
+                   (von? token) :von
+                   (seq (:von agg)) :last
+                   :else :first)
+             conj token))
+   {:first [] :von [] :last [] :jr []}
+   tokens))
+
+(defn- von-last-first [tokens]
+  (reduce
+   (fn [agg token]
+     (update agg
+             (cond (= "," token) :comma
+                   (seq (:comma agg)) :first
+                   :else (if (von? token) :von :last))
+             conj token))
+   {:first [] :von [] :last [] :jr [] :comma []}
+   tokens))
+
+(defn- von-last-jr-first [tokens]
+  (reduce
+   (fn [agg token]
+     (update agg
+             (cond (= "," token) :comma
+                   (empty? (:comma agg)) (if (von? token) :von :last)
+                   (= 1 (count (:comma agg))) :jr
+                   :else :first)
+             conj token))
+   {:first [] :von [] :last [] :jr [] :comma []}
+   tokens))
+
+(defn- parse-bibtex-single-name [name]
+  (let [tokens (mapv clean-token (re-seq tokenizer-pattern name))]
+    (select-keys
+     ((case (count (for [t tokens :when (= "," t)] t))
+        0 first-von-last
+        1 von-last-first
+        2 von-last-jr-first
+        (throw (ex-info
+                "Unparseable BibTeX name contains more than two comma tokens"
+                {:name name :error :unparseable}))) tokens)
+     [:first :last :von :jr])))
+
+(defn- parse-bibtex-name
+  "Parse a BibTeX name that may contain multiple names separated by ' and '.
+  Return a vec of parsed name maps, each representing the parse of a BibTeX name.
+  A name map has four keys whose values are each (possibly empty) vecs: :first
+  :last :von and :jr. For example, the parse for 'von Beethoven, Jr., Ludwig' is
+  {:first [Ludwig] :last [Beethoven] :von [von] :jr [Jr.]}. See
+  http://nwalsh.com/tex/texhelp/bibtx-23.html. Note: this may not work exactly
+  as BibTeX does it, but it should be good enough."
+  [name] (mapv parse-bibtex-single-name (str/split name #" and ")))
+
+(defn name-in-citation-form [name]
+  (try (last-names (parse-bibtex-name name))
+       (catch js/Error _ name)))
+
+(defn author
+  "Return an author for supplied source object. We return the author in
+  citation form if there is an author; otherwise we return the editor in
+  citation form or the title or 'no author'."
+  [{:keys [author editor title]}]
+  (let [prep (fn [x] (some-> x str/trim not-empty))
+        [author editor title] (map prep [author editor title])]
+    (cond author (name-in-citation-form author)
+          editor (name-in-citation-form editor)
+          title title
+          :else "no author")))
+
+;; TODO: it smells that year is int according to the spec but the not found
+;; value is a string.
+(defn year [source] (or (:year source) "no year"))

--- a/src/dativerf/views/form.cljs
+++ b/src/dativerf/views/form.cljs
@@ -351,22 +351,6 @@
                         :transcription morpheme-gloss}]
     [igt-translations uuid translations]]])
 
-;; Format returned is 'Fri, 22 Jan 2016 21:43:54 Z'
-;; Probably want something different eventually.
-(defn datetime->human-string [datetime]
-  (timef/unparse (timef/formatters :rfc822) datetime))
-
-;; WARNING: hacky
-;; Format returned is 'Fri, 22 Jan 2016'
-;; Probably want something different eventually.
-(defn date->human-string [date]
-  (when date
-    (let [date-str (datetime->human-string date)
-          time-sfx (->> date-str reverse (take 11) reverse (apply str))]
-      (if (= " 00:00:00 Z" time-sfx)
-        (->> date-str reverse (drop 11) reverse (apply str))
-        date-str))))
-
 (defn header-left [{form-id :uuid}]
   [re-com/h-box
    :src (at)
@@ -438,7 +422,7 @@
       [tags-as-string tags]
       [syntactic-category-as-string syntactic-category]
       [elicitation-method-as-string elicitation-method]
-      [secondary-scalar :date-elicited (date->human-string date-elicited)]
+      [secondary-scalar :date-elicited (utils/date->human-string date-elicited)]
       [person-as-string :speaker speaker]
       [person-as-string :elicitor elicitor]
       [person-as-string :verifier verifier]
@@ -446,9 +430,9 @@
       [secondary-scalar
        :datetime-entered
        (when datetime-entered
-         (datetime->human-string datetime-entered))]
+         (utils/datetime->human-string datetime-entered))]
       [person-as-string :modifier modifier]
-      [secondary-scalar :datetime-modified (datetime->human-string
+      [secondary-scalar :datetime-modified (utils/datetime->human-string
                                             datetime-modified)]
       [files-as-string files]
       [source-as-string source]

--- a/src/dativerf/views/form.cljs
+++ b/src/dativerf/views/form.cljs
@@ -1,6 +1,5 @@
 (ns dativerf.views.form
-  (:require [cljs-time.format :as timef]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [dativerf.events :as events]
             [dativerf.styles :as styles]
             [dativerf.subs :as subs]

--- a/src/dativerf/views/forms.cljs
+++ b/src/dativerf/views/forms.cljs
@@ -358,10 +358,12 @@
   (when @(re-frame/subscribe [::subs/forms-export-interface-visible?])
     (let [export-fn (:efn (forms-exporter/export @(re-frame/subscribe
                                             [::subs/forms-export-format])))
+
+          user @(re-frame/subscribe [::subs/user])
           forms @(re-frame/subscribe
                   [::subs/forms-by-ids
                    @(re-frame/subscribe [::subs/forms-current-page-forms])])
-          export-string (export-fn (vals forms))]
+          export-string (export-fn (vals forms) {:user user})]
       [re-com/v-box
        :class (styles/export-interface)
        :children

--- a/src/test/dativerf/exporters/latex/expex_test.cljs
+++ b/src/test/dativerf/exporters/latex/expex_test.cljs
@@ -1,0 +1,50 @@
+(ns test.dativerf.exporters.latex.expex-test
+  (:require [cljs.test :as t :include-macros true]
+            [dativerf.exporters.latex.expex :as sut]
+            [dativerf.utils :as utils]))
+
+(t/deftest expex-form-export-works
+  (t/is
+   (= (str
+       "\\ex\n"
+       "  \\begingl\n"
+       "    \\gla *les chiens sont lala//\n"
+       "    \\glb le-s chien-s sont la-la//\n"
+       "    \\glb DET-PL dog-PL be.3PL DIST.DEM-DIST.DEM//\n"
+       "    \\glft `the dogs are way over there'\\\\\n"
+       "    $\\ast{}$~`the wolves are way over there'\\trailingcitation{(AB, Fri, 28 Oct 2022, OLD ID: 2)}//\n"
+       "  \\endgl\n"
+       "  \\begin{itemize}\n"
+       "    \\item Comments: Alea iacta est\n"
+       "    \\item Speaker comments: Indeed\n"
+       "    \\item Speaker: AB\n"
+       "    \\item Date elicited: Fri, 28 Oct 2022\n"
+       "    \\item Source: Beethoven (1815)\n"
+       "    \\item OLD ID: 2\n"
+       "  \\end{itemize}\n"
+       "\\xe\n")
+      (sut/export {:id 2
+                   :transcription "les chiens sont lala"
+                   :grammaticality "*"
+                   :morpheme-break "le-s chien-s sont la-la"
+                   :morpheme-gloss "DET-PL dog-PL be.3PL DIST.DEM-DIST.DEM"
+                   :translations
+                   [{:transcription "the dogs are way over there" :grammaticality ""}
+                    {:transcription "the wolves are way over there" :grammaticality "*"}]
+                   :comments "Alea iacta est"
+                   :speaker-comments "Indeed"
+                   :speaker {:first-name "Anne" :last-name "Barclay"}
+                   :date-elicited (utils/parse-date-string "2022-10-28")
+                   :source {:author "von Beethoven, Jr., Ludwig"
+                            :year 1815}}))))
+
+(t/deftest trailing-citation-works
+  (t/is (= "\\trailingcitation{(Dunham (2022), OLD ID: 2)}"
+           (sut/trailing-citation
+            {:id 2
+             :source {:author "Dunham, Joel" :year 2022}})))
+  (t/is (= "\\trailingcitation{(JD, Wed, 23 Feb 2022, OLD ID: 2)}"
+           (sut/trailing-citation
+            {:id 2
+             :date-elicited (utils/parse-date-string "2022-02-23")
+             :speaker {:first-name "Joel" :last-name "Dunham"}}))))

--- a/src/test/dativerf/exporters/latex/utils_test.cljs
+++ b/src/test/dativerf/exporters/latex/utils_test.cljs
@@ -1,0 +1,51 @@
+(ns test.dativerf.exporters.latex.utils-test
+  (:require [cljs.test :as t :include-macros true]
+            [dativerf.utils :as utils]
+            [dativerf.exporters.latex.utils :as sut]))
+
+(t/deftest form-medatadata-itemization-works
+  (t/is (= (str "\\begin{itemize}\n"
+                "  \\item OLD ID: 1\n"
+                "\\end{itemize}\n")
+           (sut/form-medatadata-itemization {:id 1})))
+  (t/is (= (str "\\begin{itemize}\n"
+                "  \\item Comments: some comments\n"
+                "  \\item OLD ID: 1\n"
+                "\\end{itemize}\n")
+           (sut/form-medatadata-itemization {:comments "some comments" :id 1})))
+  (t/is (= (str "    \\begin{itemize}\n"
+                "      \\item Comments: some comments\n"
+                "      \\item Speaker comments: speaker comments\n"
+                "      \\item OLD ID: 1\n"
+                "    \\end{itemize}\n")
+           (sut/form-medatadata-itemization 4 {:comments "some comments"
+                                               :speaker-comments "speaker comments"
+                                               :id 1})))
+  (t/is (= (str "    \\begin{itemize}\n"
+                "      \\item Comments: some comments\n"
+                "      \\item Speaker comments: speaker comments\n"
+                "      \\item Speaker: BM\n"
+                "      \\item Date elicited: Fri, 28 Oct 2022\n"
+                "      \\item OLD ID: 1\n"
+                "    \\end{itemize}\n")
+           (sut/form-medatadata-itemization 4 {:comments "some comments"
+                                               :speaker-comments "speaker comments"
+                                               :speaker {:first-name "Beth"
+                                                         :last-name "Marcus"}
+                                               :date-elicited
+                                               (utils/parse-date-string "2022-10-28")
+                                               :id 1})))
+  (t/is (= (str "    \\begin{itemize}\n"
+                "      \\item Comments: some comments\n"
+                "      \\item Speaker comments: speaker comments\n"
+                "      \\item Speaker: BM\n"
+                "      \\item Source: Avery (2018)\n"
+                "      \\item OLD ID: 1\n"
+                "    \\end{itemize}\n")
+           (sut/form-medatadata-itemization 4 {:comments "some comments"
+                                               :speaker-comments "speaker comments"
+                                               :speaker {:first-name "Beth"
+                                                         :last-name "Marcus"}
+                                               :source {:author "Anne Avery"
+                                                        :year 2018}
+                                               :id 1}))))

--- a/src/test/dativerf/models/source_test.cljs
+++ b/src/test/dativerf/models/source_test.cljs
@@ -1,0 +1,99 @@
+(ns test.dativerf.models.source-test
+  (:require [cljs.test :as t :include-macros true]
+            [dativerf.models.source :as sut]
+            [dativerf.specs.source :as source-spec]))
+
+;; TODO: This test should probably be moved into a specs.source-test ns.
+(t/deftest source-spec-works
+  (t/testing "Articles are validated"
+    (let [good-article (sut/article "dunham2022" "Joel Dunham" "Great Article"
+                                    "Some Journal" 2022)
+          bad-article (sut/article "dunham2022" "" "Great Article"
+                                   "Some Journal" 2022)]
+      (t/is (true? (source-spec/write-source-valid? good-article)))
+      (t/is (false? (source-spec/write-source-valid? bad-article)))
+      ;; The problem is it's an article with an empty author:
+      (t/is (= ["article" :author]
+               (-> (source-spec/write-source-explain-data bad-article)
+                   :cljs.spec.alpha/problems
+                   first
+                   :path)))))
+
+  (t/testing "Books are validated"
+    (let [good-book (sut/book "dunham2022" "Joel Dunham" "Editors & Sons"
+                              "The Every Book" "Random House" 2022)
+          no-editor-book (sut/book "dunham2022" "Joel Dunham" nil "The Every Book"
+                                   "Random House" 2022)
+          no-author-book (sut/book "dunham2022" nil "Editors & Sons"
+                                   "The Every Book" "Random House" 2022)
+          bad-book (sut/book "dunham2022" nil nil "The Every Book"
+                             "Random House" 2022)]
+      (t/is (true? (source-spec/write-source-valid? good-book)))
+      (t/testing "Editor can be empty, if author isn't"
+        (t/is (true? (source-spec/write-source-valid? no-editor-book))))
+      (t/testing "Author can be empty, if editor isn't"
+        (t/is (true? (source-spec/write-source-valid? no-author-book))))
+      (t/testing "Both author and editor can't be empty"
+        (t/is (false? (source-spec/write-source-valid? bad-book)))
+        (t/testing "Spec tells us that author-book needs non-empty author, while
+                    editor-book needs non-empty editor."
+          (t/is (= (->> (source-spec/write-source-explain-data
+                         (sut/book "dunham2022" nil nil "The Every Book"
+                                   "Random House" 2022))
+                        :cljs.spec.alpha/problems
+                        (map :path)
+                        set)
+                   #{["book" :author-book :author]
+                     ["book" :editor-book :editor]}))))))
+
+  (t/testing "Manifesto, Conference, and Inbook are validated"
+    (t/is (true? (source-spec/write-source-valid?
+                  (sut/booklet "dunham2022" "My Manifesto"))))
+    (t/is (true? (source-spec/write-source-valid?
+                  (sut/conference "dunham2022" "Joel Dunham" "Some Conference"
+                                  "The Proceedings of Some Conference" 2022))))
+    (t/is (true? (source-spec/write-source-valid?
+                  (sut/inbook "dunham2022" "Joel Dunham" "Editors & Sons"
+                              "The Compendium" "13" "120-145" "Random House"
+                              2022)))))
+
+  (t/testing "A source without a valid type and key is invalid"
+    (t/is (false? (source-spec/write-source-valid? sut/default-write-source)))
+    (t/is (= "no method"
+             (->> (source-spec/write-source-explain-data sut/default-write-source)
+                  :cljs.spec.alpha/problems first :reason)))
+    (t/is (true? (source-spec/write-source-valid? (assoc sut/default-write-source
+                                                         :type "misc"
+                                                         :key "k"))))))
+
+(t/deftest author-in-citation-form-works
+  (doseq [[source expected]
+          {{:author "Ralph Alpher and Bethe, Hans and George Gamow"}
+           "Alpher, Bethe and Gamow"
+           {:editor "Ralph Alpher and Bethe, Hans and George Gamow" :author " "}
+           "Alpher, Bethe and Gamow"
+           {:editor "" :author " " :title "Great Article"} "Great Article"
+           {} "no author"}]
+    (t/is (= expected (sut/author-in-citation-form source)))))
+
+(t/deftest year-works
+  (doseq [[source expected]
+          {{:year 2022} 2022
+           {} -3000}]
+    (t/is (= expected (sut/year source)))))
+
+(t/deftest citation-works
+  (t/testing "author-in-citation-form works"
+    (t/is (= (repeat 3 "Dunham")
+             [(sut/author-in-citation-form {:author "Dunham, Joel"})
+              (sut/author-in-citation-form {:editor "Joel Dunham"})
+              (sut/author-in-citation-form {:title "Dunham"})]))
+    (t/is (= "no author" (sut/author-in-citation-form {}))))
+  (t/testing "citation works"
+    (t/is (= (repeat 3 "Dunham (2022)")
+             [(sut/citation {:author "Dunham, Joel" :year 2022})
+              (sut/citation {:editor "Joel Dunham" :year 2022})
+              (sut/citation {:title "Dunham" :year 2022})]))
+    (t/is (= "no author (-3000)" (sut/citation {})))
+    (t/is (= "BranVan (-3000)" (sut/citation {:author "von BranVan, Jr., Ludwig"})))
+    (t/is (= "no author (0)" (sut/citation {:year 0})))))

--- a/src/test/dativerf/utils/bibtext_test.cljs
+++ b/src/test/dativerf/utils/bibtext_test.cljs
@@ -63,19 +63,3 @@
            "Ralph Alpher and Bethe, Hans and George Gamow"
            "Alpher, Bethe and Gamow"}]
     (t/is (= expected (sut/name-in-citation-form input)))))
-
-(t/deftest author-works
-  (doseq [[source expected]
-          {{:author "Ralph Alpher and Bethe, Hans and George Gamow"}
-           "Alpher, Bethe and Gamow"
-           {:editor "Ralph Alpher and Bethe, Hans and George Gamow" :author " "}
-           "Alpher, Bethe and Gamow"
-           {:editor "" :author " " :title "Great Article"} "Great Article"
-           {} "no author"}]
-    (t/is (= expected (sut/author source)))))
-
-(t/deftest year-works
-  (doseq [[source expected]
-          {{:year 2022} 2022
-           {} "no year"}]
-    (t/is (= expected (sut/year source)))))

--- a/src/test/dativerf/utils/bibtext_test.cljs
+++ b/src/test/dativerf/utils/bibtext_test.cljs
@@ -1,0 +1,81 @@
+(ns test.dativerf.utils.bibtext-test
+  (:require [cljs.test :as t :include-macros true]
+            [dativerf.utils.bibtex :as sut]))
+
+(t/deftest parse-bibtex-single-name-works
+  (t/testing "parseable inputs are parsed correctly"
+    (doseq [[k v]
+            {"John Paul Jones"
+             {:first ["John" "Paul"] :last ["Jones"] :von [] :jr []}
+             "Jones, John Paul"
+             {:first ["John" "Paul"] :last ["Jones"] :von [] :jr []}
+             "Brinch Hansen, Per"
+             {:first ["Per"] :last ["Brinch" "Hansen"] :von [] :jr []}
+             "Ludwig von Beethoven"
+             {:first ["Ludwig"] :last ["Beethoven"] :von ["von"] :jr []}
+             "von Beethoven, Ludwig"
+             {:first ["Ludwig"] :last ["Beethoven"] :von ["von"] :jr []}
+             "{von Beethoven}, Ludwig" ;; This is bad BibTeX, but the parse is expected
+             {:first ["Ludwig"] :last ["von Beethoven"] :von [] :jr []}
+             "van der Wal, John Paul"
+             {:first ["John" "Paul"] :last ["Wal"] :von ["van" "der"] :jr []}
+             "Charles Louis Xavier Joseph de la Vallee Poussin"
+             {:first ["Charles" "Louis" "Xavier" "Joseph"] :last ["Vallee" "Poussin"]
+              :von ["de" "la"] :jr []}
+             "Donald~E. Knuth"
+             {:first ["Donald~E."] :last ["Knuth"] :von [] :jr []}
+             "{Barnes and Noble, Inc.}"
+             {:first ["Barnes and Noble, Inc."] :last [] :von [] :jr []}
+             "Ford, Jr., Henry"
+             {:first ["Henry"] :last ["Ford"] :von [] :jr ["Jr."]}
+             "{Steele Jr.}, Guy L."
+             {:first ["Guy" "L."] :last ["Steele Jr."] :von [] :jr []}
+             "Guy L. {Steele Jr.}"
+             {:first ["Guy" "L."] :last ["Steele Jr."] :von [] :jr []}
+             "von Beethoven, Jr., Ludwig"
+             {:first ["Ludwig"] :last ["Beethoven"] :von ["von"] :jr ["Jr."]}}]
+      (t/is (= v (#'sut/parse-bibtex-single-name k)))))
+  (t/testing "unparseable inputs throw exceptions as expected"
+    (t/is
+     (= :unparseable
+        (try (#'sut/parse-bibtex-single-name "A, B, C, D")
+             (catch js/Error e (:error (ex-data e))))))))
+
+(t/deftest name-tokenizer-works
+  (doseq [[input expected]
+          {"John Paul Jones" ["John" "Paul" "Jones"]
+           "Jones, John Paul" ["Jones" "," "John" "Paul"]
+           "Ludwig von Beethoven" ["Ludwig" "von" "Beethoven"]
+           "von Beethoven, Ludwig" ["von" "Beethoven" "," "Ludwig"]
+           "{Ludwig von Beethoven}" ["{Ludwig von Beethoven}"]}]
+    (t/is (= expected (re-seq sut/tokenizer-pattern input)))))
+
+(t/deftest parse-bibtex-name-works
+  (t/is (= (#'sut/parse-bibtex-name "Ralph Alpher and Bethe, Hans and George Gamow")
+           [{:first ["Ralph"] :last ["Alpher"] :von [] :jr []}
+            {:first ["Hans"] :last ["Bethe"] :von [] :jr []}
+            {:first ["George"] :last ["Gamow"] :von [] :jr []}])))
+
+(t/deftest name-in-citation-form-works
+  (doseq [[input expected]
+          {"von Beethoven, Jr., Ludwig" "Beethoven"
+           "A, B, C, D" "A, B, C, D"
+           "Ralph Alpher and Bethe, Hans and George Gamow"
+           "Alpher, Bethe and Gamow"}]
+    (t/is (= expected (sut/name-in-citation-form input)))))
+
+(t/deftest author-works
+  (doseq [[source expected]
+          {{:author "Ralph Alpher and Bethe, Hans and George Gamow"}
+           "Alpher, Bethe and Gamow"
+           {:editor "Ralph Alpher and Bethe, Hans and George Gamow" :author " "}
+           "Alpher, Bethe and Gamow"
+           {:editor "" :author " " :title "Great Article"} "Great Article"
+           {} "no author"}]
+    (t/is (= expected (sut/author source)))))
+
+(t/deftest year-works
+  (doseq [[source expected]
+          {{:year 2022} 2022
+           {} "no year"}]
+    (t/is (= expected (sut/year source)))))

--- a/src/test/dativerf/utils_test.cljs
+++ b/src/test/dativerf/utils_test.cljs
@@ -16,3 +16,11 @@
               {:AnotherKey "abc"
                'symbolKey "def"}
               {:a_b {:cDogFish 444}}]}))))
+
+(t/deftest get-empty-string->nil-works
+  (t/is (= (repeat 4 nil)
+           [(sut/get-empty-string->nil {} :a)
+            (sut/get-empty-string->nil {:a nil} :a)
+            (sut/get-empty-string->nil {:a ""} :a)
+            (sut/get-empty-string->nil {:a "   "} :a)]))
+  (t/is (= "a" (sut/get-empty-string->nil {:a " a   "} :a))))


### PR DESCRIPTION
Fixes #44 

## Rationale

We want DativeRF users to be able to export individual forms and lists of forms in ExPex LaTeX format.

## Considerations

This work required a fair amount of work on specs and models, primarily the source model, which is based on the BibTeX bibliographic entry type.

## Changes

- Add ExPex LaTeX exporter
  - Single forms can be exported in ExPex IGT LaTeX format.
  - Lists of forms can be exported in ExPex IGT LaTeX format.
- Create model and spec for Source resources
  - The main feature arising from the culmination of this work is the ability to extract a citation---e.g., "Chomsky (1965)"---from a source.
- General refactoring/reorganizing of specs and models
- Add utils.bibtex ns for working with BibTeX entries

## Sample

### Input Forms

```
[
  {
    "date_elicited": false,
    "tags": [],
    "morpheme_break_ids": null,
    "verifier": null,
    "modifier": {
      "id": 4,
      "first_name": "Joel",
      "last_name": "Dunham",
      "role": "administrator"
    },
    "narrow_phonetic_transcription": "",
    "syntactic_category_string": null,
    "semantics": "",
    "enterer": {
      "id": 4,
      "first_name": "Joel",
      "last_name": "Dunham",
      "role": "administrator"
    },
    "datetime_modified": {
      "date": "2022-06-29T16:12:26.524Z"
    },
    "comments": "",
    "elicitation_method": null,
    "morpheme_gloss": "",
    "source": null,
    "syntactic_category": null,
    "break_gloss_category": null,
    "grammaticality": "",
    "speaker_comments": "",
    "morpheme_gloss_ids": null,
    "status": "tested",
    "syntax": "",
    "morpheme_break": "",
    "id": 57,
    "phonetic_transcription": "",
    "files": [],
    "datetime_entered": {
      "date": "2022-06-29T16:12:26.524Z"
    },
    "uuid": "306f9898-e50b-4dc8-b4c0-1182189acd09",
    "speaker": null,
    "transcription": "q",
    "elicitor": null,
    "translations": [
      {
        "id": 58,
        "transcription": "q",
        "grammaticality": ""
      }
    ]
  },
  {
    "date_elicited": false,
    "tags": [],
    "morpheme_break_ids": [
      [
        [],
        []
      ],
      [
        [],
        []
      ]
    ],
    "verifier": null,
    "modifier": {
      "id": 4,
      "first_name": "Joel",
      "last_name": "Dunham",
      "role": "administrator"
    },
    "narrow_phonetic_transcription": "",
    "syntactic_category_string": "?-? ?-?",
    "semantics": "",
    "enterer": {
      "id": 4,
      "first_name": "Joel",
      "last_name": "Dunham",
      "role": "administrator"
    },
    "datetime_modified": {
      "date": "2022-07-02T18:27:49.649Z"
    },
    "comments": "",
    "elicitation_method": null,
    "morpheme_gloss": "DET-PL dog-PL",
    "source": {
      "institution": "",
      "publisher": "",
      "key": "test",
      "school": "",
      "type": "article",
      "journal": "Fake Journal",
      "title": "Greatest Article Ever!",
      "pages": "",
      "note": "",
      "author": "Dunham, Joel",
      "chapter": "",
      "year": 2022,
      "crossref": "",
      "id": 1,
      "editor": "",
      "booktitle": ""
    },
    "syntactic_category": null,
    "break_gloss_category": "le|DET|?-s|PL|? chien|dog|?-s|PL|?",
    "grammaticality": "*",
    "speaker_comments": "",
    "morpheme_gloss_ids": [
      [
        [],
        []
      ],
      [
        [],
        []
      ]
    ],
    "status": "tested",
    "syntax": "",
    "morpheme_break": "le-s chien-s",
    "id": 58,
    "phonetic_transcription": "le ∫je",
    "files": [],
    "datetime_entered": {
      "date": "2022-06-30T00:54:16.876Z"
    },
    "uuid": "1ede623b-353d-4200-b9dd-77bfed088c7c",
    "speaker": null,
    "transcription": "les chiens",
    "elicitor": null,
    "translations": [
      {
        "id": 61,
        "transcription": "the dogs",
        "grammaticality": ""
      },
      {
        "id": 62,
        "transcription": "the wolves",
        "grammaticality": "*"
      }
    ]
  }
]
```

### Output ExPex LaTeX

```

\documentclass[a4paper,english]{article}
\usepackage{fixltx2e}
\usepackage{cmap}
\usepackage[T1]{fontenc}
\usepackage{ifthen}
\usepackage{babel}
\usepackage{mathptmx}
\usepackage[scaled=.90]{helvet}
\usepackage{courier}
\usepackage{fontspec}
\defaultfontfeatures{Mapping=tex-text}
\usepackage{xunicode}
\usepackage{xltxtra}
\setmainfont{Charis SIL}
\usepackage{expex}
\begin{document}
\title{DativeRF Expex LaTeX Export}
\author{Joel Dunham}
\date{Mon, 04 Jul 2022}
\maketitle

\ex
  \begingl
    \gla q//
    \glft `q'\trailingcitation{(OLD ID: 57)}//
  \endgl
  \begin{itemize}
    \item OLD ID: 57
  \end{itemize}
\xe

\ex
  \begingl
    \gla *les chiens//
    \glb le ∫je//
    \glb le-s chien-s//
    \glb DET-PL dog-PL//
    \glft `the dogs'\\
    $\ast{}$~`the wolves'\trailingcitation{(Dunham (2022), OLD ID: 58)}//
  \endgl
  \begin{itemize}
    \item Source: Dunham (2022)
    \item OLD ID: 58
  \end{itemize}
\xe

\end{document}
```
<img width="978" alt="expex-export-pdf" src="https://user-images.githubusercontent.com/2504271/177089201-87a395b2-cc75-4deb-9d8e-fbce7d768dfa.png">

