### PR TITLE
Retry network requests

### DIFF
--- a/src/dativerf/db.cljs
+++ b/src/dativerf/db.cljs
@@ -77,6 +77,7 @@
        :login/password ""
        :login/state :dativerf.fsms.login/is-ready
        :login/invalid-reason nil
+       :login/retries 0
        ;; forms browse state
        :forms-paginator/items-per-page 10
        :forms-paginator/current-page-forms []
@@ -96,6 +97,7 @@
        :forms/new-form-secondary-fields-visible? false
        :forms/form-to-delete nil
        :forms/force-reload? false
+       :forms-page/retries 0
        ;; routing state
        :forms/previous-route nil
        :forms/previous-browse-route nil

--- a/src/dativerf/db.cljs
+++ b/src/dativerf/db.cljs
@@ -70,6 +70,7 @@
        :old nil
        :old-states {}
        :user nil
+       :system/error nil
        ;; settings state
        :settings/active-tab :server
        ;; login state

--- a/src/dativerf/subs.cljs
+++ b/src/dativerf/subs.cljs
@@ -15,6 +15,8 @@
 
 (re-frame/reg-sub ::active-settings-tab (fn [db _] (:settings/active-tab db)))
 
+(re-frame/reg-sub ::system-error (fn [db _] (:system/error db)))
+
 (re-frame/reg-sub :login/username (fn [db] (:login/username db)))
 (re-frame/reg-sub :login/password (fn [db] (:login/password db)))
 (re-frame/reg-sub :login/state (fn [db _] (:login/state db)))

--- a/src/dativerf/views.cljs
+++ b/src/dativerf/views.cljs
@@ -8,6 +8,7 @@
             [dativerf.subs :as subs]
             [dativerf.utils :as utils]
             dativerf.views.old-settings
+            [dativerf.views.error :as error]
             dativerf.views.forms
             dativerf.views.home
             dativerf.views.login
@@ -102,4 +103,5 @@
      :padding "1em"
      :children [[title]
                 [menu]
-                (routes/tabs @active-route)]]))
+                (routes/tabs @active-route)
+                [error/modal]]]))

--- a/src/dativerf/views/error.cljs
+++ b/src/dativerf/views/error.cljs
@@ -1,0 +1,58 @@
+(ns dativerf.views.error
+  (:require [re-frame.core :as re-frame]
+            [re-com.core :as re-com :refer [at]]
+            [dativerf.events :as events]
+            [dativerf.subs :as subs]))
+
+(def generic-advice
+  "Try navigating to the home page and then retry what you were doing.
+  If that doesn't work, try reloading the page.")
+
+(def errors
+  {:default
+   (str "Oops! An unidentified error occurred. " generic-advice)
+   :fetch-first-page-forms-retries-exceeded
+   (str "Uh-oh! Dative tried three times to fetch the first page of forms from"
+        " this OLD and all three attempts failed! " generic-advice)
+   :fetch-first-page-forms-failed
+   (str "Fiddlesticks! Dative failed to fetch the first page of forms from this"
+        " OLD! " generic-advice)
+   :form-not-fetched
+   (str "Shucks! We were unable to fetch that form for you!" generic-advice)
+   :authenticate-retries-exceeded
+   (str "Rats! Dative tried three times to authenticate to the OLD with your"
+        " credentials but all three attempts failed! " generic-advice)
+   :authenticate-failed
+   (str "Tarnation! Your attempt to authenticated failed in an unexpected"
+        " manner." generic-advice)})
+
+(defn modal []
+  (when-let [system-error @(re-frame/subscribe [::subs/system-error])]
+    [re-com/modal-panel
+     :src (at)
+     :backdrop-color "grey"
+     :backdrop-opacity 0.4
+     :backdrop-on-click (fn [] (re-frame/dispatch
+                                [::events/disregard-system-error]))
+     :child
+     [re-com/v-box
+      :max-width "800px"
+      :children
+      [[re-com/alert-box
+        :alert-type :danger
+        :heading "System Error"
+        :body (get errors system-error (:default errors))]
+       [re-com/h-box
+        :gap "10px"
+        :justify :end
+        :children
+        [[re-com/button
+          :label "Ok"
+          :tooltip "dismiss the error"
+          :attr {:auto-focus true
+                 :on-key-up (fn [e]
+                              (when (= "Escape" (.-key e))
+                                (re-frame/dispatch
+                                 [::events/disregard-system-error])))}
+          :on-click (fn [_] (re-frame/dispatch
+                              [::events/disregard-system-error]))]]]]]]))

--- a/src/dativerf/views/forms.cljs
+++ b/src/dativerf/views/forms.cljs
@@ -453,19 +453,12 @@
 
 (defmethod routes/tabs :forms-last-page [_]
   (let [last-page @(re-frame/subscribe [::subs/forms-last-page])
-        current-page @(re-frame/subscribe [::subs/forms-current-page])
-        form-ids @(re-frame/subscribe [::subs/forms-current-page-forms])
-        force-reload? @(re-frame/subscribe [::subs/forms-force-reload?])
-        forms (filter some?
-                      (for [form-id form-ids]
-                        @(re-frame/subscribe [::subs/form-by-id form-id])))]
+        force-reload? @(re-frame/subscribe [::subs/forms-force-reload?])]
     (cond force-reload?
           (do (re-frame/dispatch [::events/fetch-forms-last-page])
               (re-frame/dispatch [::events/turn-off-force-forms-reload])
               [re-com/throbber :size :large])
-          (and last-page
-               (= last-page current-page)
-               (= (count form-ids) (count forms)))
+          last-page
           (re-frame/dispatch
            [::events/navigate
             (assoc-in (forms-page-route) [:route-params :page] last-page)])

--- a/src/dativerf/views/login.cljs
+++ b/src/dativerf/views/login.cljs
@@ -98,6 +98,7 @@
    :child
    [re-com/button
     :label "Logout"
+    :attr {:auto-focus true}
     :on-click (fn [_e] (re-frame/dispatch [::events/user-clicked-logout]))]])
 
 (defn login-tab []


### PR DESCRIPTION
Fixes #43 

## Rationale

Sometimes requests to login or fetch the first page of forms of an OLD fail in a non-standard way. It's not because the user's credentials were wrong, or because the forms fetch request was malformed. It's an issue with the OLD in production, and is related to CORS and 500 errors because the DB connection has timed out.

While this should be fixed in the OLD, we can work around this issue in Dative by implementing retries. Typically, the first retry succeeds because the initial attempt has awakened the OLD.

## Changes

- Add retries to authenticate and forms fetch
  - If an authentication (POST) request fails with a non-response, we assume it is a false failure and retry. We retry up to 3 times.
  - We now perform the same behaviour for a non-response failure to fetch the first page of forms.
  - Alter events and views.forms namespaces so that we no longer make a second redundant request to get the first page of forms.
- Add error modal for when things go wrong
    - If an authentication attempt fails (in an unexpected way, i.e., not because the credentials were wrong) or we failed to fetch the first page of forms from an OLD, display an error modal dialog that helps the user understand what went wrong and what they might do about it.