### PR TITLE
Fix change items per page

### DIFF
--- a/src/dativerf/db.cljs
+++ b/src/dativerf/db.cljs
@@ -66,9 +66,9 @@
 (def default-db
   (-> {:name "Dative"
        :active-route {:handler :home}
-       :olds []
+       :olds [] ;; the OLDs from servers.json from Dative static
        :old nil
-       :old-states {}
+       :old-states {} ;; the cache of OLD-specific state: forms, resources, form-specific view state, etc.
        :user nil
        :system/error nil
        ;; settings state
@@ -114,3 +114,10 @@
   {:expanded? expanded?
    :export-interface-visible? false
    :export-format :plain-text})
+
+(defn soft-reset-dative-state
+  "Reset state to default but keep our OLDs so we can login again."
+  [{:keys [olds] :as db}]
+  (if (seq olds)
+    (assoc default-db :olds olds)
+    default-db))

--- a/src/dativerf/db.cljs
+++ b/src/dativerf/db.cljs
@@ -87,6 +87,7 @@
        :forms-paginator/count 0
        :forms-paginator/first-form 0
        :forms-paginator/last-form 0
+       :forms-paginator/cache {}
        :forms/labels-on? false
        :forms/expanded? false
        :forms/export-interface-visible? false
@@ -117,7 +118,7 @@
 
 (defn soft-reset-dative-state
   "Reset state to default but keep our OLDs so we can login again."
-  [{:keys [olds] :as db}]
+  [{:keys [olds]}]
   (if (seq olds)
     (assoc default-db :olds olds)
     default-db))

--- a/src/dativerf/events.cljs
+++ b/src/dativerf/events.cljs
@@ -809,20 +809,21 @@
 (re-frame/reg-event-fx
  ::user-changed-items-per-page
  (fn [{:keys [db]} [_ items-per-page]]
-            (let [first-form (:forms-paginator/first-form db)
-                  current-page (Math/ceil (/ first-form items-per-page))
-                  last-page (Math/ceil (/ (:forms-paginator/count db)
-                                          items-per-page))
-                  route {:handler :forms-page
-                         :route-params
-                         {:old (old-model/slug db)
-                          :items-per-page items-per-page
-                          :page current-page}}]
-              {:db (assoc db
-                          :forms-paginator/items-per-page items-per-page
-                          :forms-paginator/current-page current-page
-                          :forms-paginator/last-page last-page)
-               :fx [[:dispatch [::navigate route]]]})))
+   (let [first-form (:forms-paginator/first-form db)
+         current-page (Math/ceil (/ first-form items-per-page))
+         last-page (Math/ceil (/ (:forms-paginator/count db)
+                                 items-per-page))
+         route {:handler :forms-page
+                :route-params
+                {:old (old-model/slug db)
+                 :items-per-page items-per-page
+                 :page current-page}}]
+     {:db (assoc db
+                 :forms/force-reload? true
+                 :forms-paginator/items-per-page items-per-page
+                 :forms-paginator/current-page current-page
+                 :forms-paginator/last-page last-page)
+      :fx [[:dispatch [::navigate route]]]})))
 
 ;; "New Form" interface events
 

--- a/src/dativerf/views/forms.cljs
+++ b/src/dativerf/views/forms.cljs
@@ -445,9 +445,16 @@
         forms (filter some?
                       (for [form-id form-ids]
                         @(re-frame/subscribe [::subs/form-by-id form-id])))]
-    (if (or (zero? forms-count)
-            (and (= page current-page) (= (count form-ids) (count forms))))
+    (cond
+      @(re-frame/subscribe [::subs/forms-force-reload?])
+      (do (re-frame/dispatch [::events/turn-off-force-forms-reload])
+          (re-frame/dispatch [::events/fetch-forms-page page
+                              @(re-frame/subscribe [::subs/forms-items-per-page])])
+          [re-com/throbber :size :large])
+      (or (zero? forms-count)
+          (and (= page current-page) (= (count form-ids) (count forms))))
       [forms-tab]
+      :else
       (do (re-frame/dispatch [::events/fetch-forms-page page items-per-page])
           [re-com/throbber :size :large]))))
 


### PR DESCRIPTION
Fixes #46 

## Rationale

When a user changes the items per page dropdown value, we want to show (at most) the desired number of forms on the page.

## Changes

- Fix behaviour when user changes `items-per-page`
  - Trigger a forced reload when the user changes the items per page.
    - This fixes a bug where navigating to the first page of forms and then changing the items-per-page resulted in inconsistent and unexpected behaviour.
- Use the cache of in-memory forms during browse
  - Dative now avoids network requests to fetch OLD forms if it already has the forms in memory.
- Remove special-case event and handle logout better
  - Remove `::forms-first-page-for-last-page-fetched` event. We can just use `::forms-page-fetched`.
  - On logout (whether or not server de-authenticates), reset Dative's state to the default.