### PR TITLE
Refactor new form interface

### DIFF
--- a/src/dativerf/models/application_settings.cljs
+++ b/src/dativerf/models/application_settings.cljs
@@ -1,7 +1,6 @@
 (ns dativerf.models.application-settings
   (:require [dativerf.specs.application-settings :as spec]
             [dativerf.utils :as utils]
-            [clojure.set :as set]
             [clojure.string :as str]))
 
 ;; Metadata about Application Settings Fields

--- a/src/dativerf/models/form.cljs
+++ b/src/dativerf/models/form.cljs
@@ -1,8 +1,66 @@
 (ns dativerf.models.form
   "Functionality for getting form entities from the in-memory db and validating
   forms."
-  (:require [dativerf.utils :as utils]
-            [dativerf.specs.form :as form-specs]))
+  (:require [dativerf.specs.form :as spec]
+            [dativerf.utils :as utils]))
+
+(def metadata
+  {:narrow-phonetic-transcription
+   {:label "narr. phon. transcr."
+    :description "A narrow phonetic transcription, probably in IPA."}
+   :phonetic-transcription
+   {:label "phon. transcr."
+    :description "A phonetic transcription, probably in IPA."}
+   :transcription
+   {:description "A transcription, probably orthographic."}
+   :morpheme-break
+   {:description "A sequence of morpheme shapes and delimiters. The OLD assumes
+              phonemic shapes (e.g., “in-perfect”), but phonetic (i.e.,
+              allomorphic, e.g., “im-perfect”) ones are ok."}
+   :morpheme-gloss
+   {:description "A sequence of morpheme glosses and delimiters, isomorphic to
+             the morpheme break sequence, e.g., “NEG-parfait”."}
+   :translations
+   {:description "One or more translations for the form. Each translation may have
+              its own grammaticality/acceptibility specification."}
+   :comments
+   {:description "General-purpose field for notes and commentary about the form."}
+   :speaker-comments
+   {:description "Field specifically for comments about the form made by the
+              speaker/consultant."}
+   :elicitation-method
+   {:description "How the form was elicited. Examples: “volunteered”, “judged
+              elicitor’s utterance”, “translation task”, etc."}
+   :tags
+   {:description "Tags for categorizing your forms."}
+   :syntactic-category
+   {:description "The category (syntactic and/or morphological) of the form."}
+   :date-elicited
+   {:description "The date this form was elicited"}
+   :speaker
+   {:description "The speaker (consultant) who produced or judged the form."}
+   :elicitor
+   {:description "The linguistic fieldworker who elicited the form with the help
+              of the consultant."}
+   :verifier
+   {:description "The user who has verified the reliability/accuracy of this form."}
+   :source
+   {:description "The textual source (e.g., research paper, text collection, book
+              of learning materials) from which the form was drawn, if
+              applicable."}
+   :files
+   {:description "Digital files (e.g., audio, video, image or text) that are
+              associated to this form."}
+   :syntax
+   {:description "A syntactic phrase structure representation in some kind of
+              string-based format."}
+   :semantics
+   {:description "A semantic representation of the meaning of the form in some
+              string-based format."}
+   :status
+   {:description "The status of the form: “tested” for data that have been
+              elicited/tested/verified with a consultant or “requires testing”
+              for data that are posited and still need testing/elicitation."}})
 
 (defn new-form [db]
   (-> (utils/select-keys-by-ns "new-form" db)
@@ -36,7 +94,7 @@
 
 (defn new-form-field-specific-validation-error-messages [new-form]
   (->> new-form
-       form-specs/write-form-explain-data
+       spec/write-form-explain-data
        :cljs.spec.alpha/problems
        (map (comp first :path))
        (filter some?)
@@ -53,3 +111,48 @@
       (update :datetime-entered utils/datetime-string?)
       (update :datetime-modified utils/datetime-string?)
       (update :uuid uuid)))
+
+(defn process-forms-new-response
+  "Validate a GET forms/new response fetched from the OLD."
+  [resources]
+  (let [data (reduce
+              (fn [agg [extractor key]]
+                (if-let [d (extractor resources)]
+                  (assoc agg key (utils/->kebab-case-recursive d))
+                  agg))
+              {}
+              [[:elicitation_methods :elicitation-methods]
+               [:grammaticalities :grammaticalities]
+               [:sources :sources]
+               [:speakers :speakers]
+               [:syntactic_categories :syntactic-categories]
+               [:tags :tags]
+               [:users :users]])]
+    (when-not (spec/new-data-valid? data)
+      (throw (ex-info "Invalid New Form Data"
+                      {:new-data data
+                       :error-code :invalid-new-form-data
+                       :explain-data (spec/new-data-explain-data data)})))
+    data))
+
+(def editable-keys
+  [:comments
+   :date-elicited
+   :elicitation-method
+   :elicitor
+   :files
+   :morpheme-break
+   :morpheme-gloss
+   :narrow-phonetic-transcription
+   :phonetic-transcription
+   :semantics
+   :source
+   :speaker
+   :speaker-comments
+   :status
+   :syntactic-category
+   :syntax
+   :tags
+   :transcription
+   :translations
+   :verifier])

--- a/src/dativerf/specs/application_settings.cljs
+++ b/src/dativerf/specs/application_settings.cljs
@@ -1,8 +1,6 @@
 (ns dativerf.specs.application-settings
   (:require [clojure.spec.alpha :as s]
-            [clojure.set :as set]
             [dativerf.specs.common :as common]
-            [dativerf.specs.language :as language]
             [dativerf.specs.orthography :as orthography]
             [dativerf.specs.user :as user]))
 

--- a/src/dativerf/specs/elicitation_method.cljs
+++ b/src/dativerf/specs/elicitation_method.cljs
@@ -1,0 +1,9 @@
+(ns dativerf.specs.elicitation-method
+  (:require [clojure.spec.alpha :as s]
+            [dativerf.specs.common :as common]))
+
+(s/def ::id ::common/id)
+(s/def ::name (partial common/string-max-len? 255))
+(s/def ::mini-elicitation-method (s/keys :req-un [::id
+                                                  ::name]))
+(s/def ::mini-elicitation-methods (s/coll-of ::mini-elicitation-method))

--- a/src/dativerf/specs/form.cljs
+++ b/src/dativerf/specs/form.cljs
@@ -5,8 +5,12 @@
             [clojure.string :as str]
             [dativerf.db :as db]
             [dativerf.specs.common :as common]
+            [dativerf.specs.elicitation-method :as elicitation-method]
             [dativerf.specs.file :as file]
             [dativerf.specs.source :as source]
+            [dativerf.specs.speaker :as speaker]
+            [dativerf.specs.syntactic-category :as syntactic-category]
+            [dativerf.specs.tag :as tag]
             [dativerf.specs.user :as user]
             [dativerf.utils :as utils]
             [goog.string :as gstring]
@@ -15,43 +19,11 @@
 ;; TODO: this ns is called form but there are specs for all types of resources
 ;; in here.
 
-(s/def :tag/id ::common/id)
-(s/def :tag/name string?)
-(s/def :tag/description string?)
-(s/def :tag/datetime-modified ::common/datetime-string)
-(s/def ::tag (s/keys :req-un [:tag/id
-                              :tag/name
-                              :tag/description
-                              :tag/datetime-modified]))
-(s/def ::tags (s/coll-of ::tag))
-
-(s/def :syntactic-category/id ::common/id)
-(s/def :syntactic-category/name string?)
-(s/def ::syntactic-category (s/keys :req-un [:syntactic-category/id
-                                             :syntactic-category/name]))
-(s/def ::syntactic-categories (s/coll-of ::syntactic-category))
-
-(s/def :elicitation-method/id ::common/id)
-(s/def :elicitation-method/name string?)
-(s/def ::elicitation-method (s/keys :req-un [:elicitation-method/id
-                                             :elicitation-method/name]))
-(s/def ::elicitation-methods (s/coll-of ::elicitation-method))
-
 (defn uuid-string? [x]
   (and (string? x)
        (re-find #"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
                 x)))
 (s/def ::uuid-string uuid-string?)
-
-(s/def :speaker/id ::common/id)
-(s/def :speaker/first-name string?)
-(s/def :speaker/last-name string?)
-(s/def :speaker/dialect string?)
-(s/def ::speaker (s/keys :req-un [:speaker/id
-                                  :speaker/first-name
-                                  :speaker/last-name
-                                  :speaker/dialect]))
-(s/def ::speakers (s/coll-of ::speaker))
 
 (s/def :translation/id ::common/id)
 (s/def :translation/transcription string?)
@@ -63,7 +35,7 @@
 
 ;; Form spec
 
-(s/def :form/tags ::tags)
+(s/def :form/tags ::tag/tags)
 (s/def :form/date-elicited (s/nilable ::common/date-string))
 (s/def :form/narrow-phonetic-transcription string?)
 (s/def :form/enterer (s/nilable ::user/mini-user))
@@ -73,7 +45,7 @@
 (s/def :form/verifier (s/nilable ::user/mini-user))
 (s/def :form/break-gloss-category string?)
 (s/def :form/modifier (s/nilable ::user/mini-user))
-(s/def :form/syntactic-category (s/nilable ::syntactic-category))
+(s/def :form/syntactic-category (s/nilable ::syntactic-category/mini-syntactic-category))
 (s/def :form/speaker-comments string?)
 ;; TODO: better spec for morpheme-gloss-ids
 (s/def :form/morpheme-gloss-ids (s/nilable (s/coll-of any?)))
@@ -88,11 +60,11 @@
 (s/def :form/id ::common/id)
 (s/def :form/morpheme-gloss (s/nilable string?))
 (s/def :form/files ::file/mini-files)
-(s/def :form/elicitation-method (s/nilable ::elicitation-method))
+(s/def :form/elicitation-method (s/nilable ::elicitation-method/mini-elicitation-method))
 (s/def :form/datetime-modified ::common/datetime-string)
 (s/def :form/uuid ::uuid-string)
 (s/def :form/morpheme-break string?)
-(s/def :form/speaker (s/nilable ::speaker))
+(s/def :form/speaker (s/nilable ::speaker/mini-speaker))
 ;; TODO: better spec for morpheme-break-ids
 (s/def :form/morpheme-break-ids (s/nilable (s/coll-of any?)))
 (s/def :form/phonetic-transcription string?)
@@ -198,8 +170,8 @@
 (s/def :write-form/semantics (s/and string? (partial max-length 1023)))
 (s/def :write-form/status #{"tested" "requires testing"})
 (s/def :write-form/elicitation-method (s/nilable ::common/id))
-(s/def :write-form/syntactic-category (s/nilable ::common/id))
-(s/def :write-form/speaker (s/nilable ::common/id))
+(s/def :write-form/syntactic-category (s/nilable ::syntactic-category/id))
+(s/def :write-form/speaker (s/nilable ::speaker/id))
 (s/def :write-form/elicitor (s/nilable ::common/id))
 (s/def :write-form/verifier (s/nilable ::common/id))
 (s/def :write-form/source (s/nilable ::common/id))
@@ -242,6 +214,25 @@
                     :write-form/date-elicited])
    one-non-empty-transcription-type-value))
 
+(s/def :new-form/elicitation-methods ::elicitation-method/mini-elicitation-methods)
+(s/def :new-form/grammaticality string?)
+(s/def :new-form/grammaticalities (s/coll-of :new-form/grammaticality))
+(s/def :new-form/sources ::source/mini-sources)
+(s/def :new-form/speakers ::speaker/mini-speakers)
+(s/def :new-form/syntactic-categories ::syntactic-category/mini-syntactic-categories)
+(s/def :new-form/tags ::tag/mini-tags)
+(s/def :new-form/users ::user/mini-users)
+(s/def :new-form/new-data (s/keys :opt-un [:new-form/elicitation-methods
+                                           :new-form/grammaticalities
+                                           :new-form/sources
+                                           :new-form/speakers
+                                           :new-form/syntactic-categories
+                                           :new-form/tags
+                                           :new-form/users]))
+
+(def new-data-valid? (partial s/valid? :new-form/new-data))
+(def new-data-explain-data (partial s/explain-data :new-form/new-data))
+
 (def write-form-valid? (partial s/valid? ::write-form))
 (def write-form-explain-data (partial s/explain-data ::write-form))
 
@@ -273,7 +264,5 @@
           {:transcription 2
            :translations
            [{:transcription "b" :grammaticality ""}]}))
-
-
 
 )

--- a/src/dativerf/specs/source.cljs
+++ b/src/dativerf/specs/source.cljs
@@ -92,7 +92,6 @@
 (s/def ::mini-source (s/keys :req-un
                              [::id
                               ::crossref
-                              ::crossref-source
                               ::type
                               ::key
                               ::journal
@@ -106,7 +105,10 @@
                               ::year
                               ::author
                               ::title
-                              ::note]))
+                              ::note]
+                             :opt-un
+                             [::crossref-source]))
+(s/def ::mini-sources (s/coll-of ::mini-source))
 
 ;; TODO: there is a lot of repetition between ::mini-source, ::source and
 ;; ::write-source. We could consider being clever and using s/merge to DRY this

--- a/src/dativerf/specs/speaker.cljs
+++ b/src/dativerf/specs/speaker.cljs
@@ -1,0 +1,13 @@
+(ns dativerf.specs.speaker
+  (:require [clojure.spec.alpha :as s]
+            [dativerf.specs.common :as common]))
+
+(s/def ::id ::common/id)
+(s/def ::first-name (partial common/string-max-len? 255))
+(s/def ::last-name (partial common/string-max-len? 255))
+(s/def ::dialect (partial common/string-max-len? 255))
+(s/def ::mini-speaker (s/keys :req-un [::id
+                                       ::first-name
+                                       ::last-name
+                                       ::dialect]))
+(s/def ::mini-speakers (s/coll-of ::mini-speaker))

--- a/src/dativerf/specs/syntactic_category.cljs
+++ b/src/dativerf/specs/syntactic_category.cljs
@@ -1,0 +1,9 @@
+(ns dativerf.specs.syntactic-category
+  (:require [clojure.spec.alpha :as s]
+            [dativerf.specs.common :as common]))
+
+(s/def ::id ::common/id)
+(s/def ::name (partial common/string-max-len? 255))
+(s/def ::mini-syntactic-category (s/keys :req-un [::id
+                                                  ::name]))
+(s/def ::mini-syntactic-categories (s/coll-of ::mini-syntactic-category))

--- a/src/dativerf/specs/tag.cljs
+++ b/src/dativerf/specs/tag.cljs
@@ -1,0 +1,17 @@
+(ns dativerf.specs.tag
+  (:require [clojure.spec.alpha :as s]
+            [dativerf.specs.common :as common]))
+
+(s/def ::id ::common/id)
+(s/def ::name (partial common/string-max-len? 255))
+(s/def ::description string?)
+(s/def ::datetime-modified ::common/datetime-string)
+(s/def ::tag (s/keys :req-un [::id
+                              ::name
+                              ::description
+                              ::datetime-modified]))
+(s/def ::tags (s/coll-of ::tag))
+
+(s/def ::mini-tag (s/keys :req-un [::id
+                                   ::name]))
+(s/def ::mini-tags (s/coll-of ::mini-tag))

--- a/src/dativerf/subs.cljs
+++ b/src/dativerf/subs.cljs
@@ -4,8 +4,7 @@
    [dativerf.fsms.login :as login]
    [dativerf.models.application-settings :as application-settings]
    [dativerf.models.form :as form-model]
-   [dativerf.models.old :as old-model]
-   [dativerf.utils :as utils]))
+   [dativerf.models.old :as old-model]))
 
 (doseq [[subscription path]
         {::active-route [:active-route]
@@ -77,8 +76,14 @@
      (get-in db [:new-form/translations index new-form-translations-key]))))
 
 (doseq [[subscription mini-resource]
-        {::languages :languages
+        {::grammaticalities :grammaticalities
+         ::languages :languages
+         ::mini-elicitation-methods :mini-elicitation-methods
          ::mini-orthographies :mini-orthographies
+         ::mini-sources :mini-sources
+         ::mini-speakers :mini-speakers
+         ::mini-syntactic-categories :mini-syntactic-categories
+         ::mini-tags :mini-tags
          ::mini-users :mini-users}]
   (re-frame/reg-sub
    subscription

--- a/src/dativerf/views/error.cljs
+++ b/src/dativerf/views/error.cljs
@@ -16,6 +16,10 @@
   (str "The new application settings data fetched from the OLD do not appear to"
        " be valid. " generic-advice))
 
+(def invalid-form-new
+  (str "The new form data fetched from the OLD do not appear to"
+       " be valid. " generic-advice))
+
 (def errors
   {:default
    (str "Oops! An unidentified error occurred. " generic-advice)
@@ -37,6 +41,8 @@
    :application-settings-invalid invalid-application-settings
    :new-application-settings-data-invalid-by-spec invalid-application-settings-new
    :new-application-settings-data-invalid invalid-application-settings-new
+   :new-form-data-invalid-by-spec invalid-form-new
+   :new-form-data-invalid invalid-form-new
    :unicode-data-not-fetched
    (str "Sadly Dative was unable to fetch the Unicode data that allows it to"
         " name the characters used in orthographies and inventories. "

--- a/src/dativerf/views/widgets.cljs
+++ b/src/dativerf/views/widgets.cljs
@@ -105,29 +105,31 @@
   text. The metadata map should have a key matching attr. If it does not have
   that key, a human-readable representation of the attr will be used as label
   and tooltip."
-  [metadata attr]
-  (let [showing? (r/atom false)
-        tooltip* (mutils/description metadata attr)]
-    [re-com/popover-tooltip
-     :label tooltip*
-     :showing? showing?
-     :width (when (> (count tooltip*) 80) "400px")
-     :anchor
-     [re-com/box
-      :class (str (styles/wider-attr-label) " " (styles/objlang) " "
-                  (styles/actionable))
-      :align :end
-      :padding "0 1em 0 0"
-      :attr {:on-mouse-over (re-com/handler-fn (reset! showing? true))
-             :on-mouse-out (re-com/handler-fn (reset! showing? false))}
-      :child (mutils/label-str metadata attr)]]))
+  ([metadata attr] (label-with-tooltip metadata styles/wider-attr-label attr))
+  ([metadata style attr]
+   (let [showing? (r/atom false)
+         tooltip (if attr (mutils/description metadata attr) "")]
+     [re-com/popover-tooltip
+      :label tooltip
+      :showing? showing?
+      :width (when (and attr (> (count tooltip) 80)) "400px")
+      :anchor
+      [re-com/box
+       :class (str (style) " " (styles/objlang) " " (styles/actionable))
+       :align :end
+       :padding "0 1em 0 0"
+       :attr {:on-mouse-over (re-com/handler-fn (reset! showing? true))
+              :on-mouse-out (re-com/handler-fn (reset! showing? false))}
+       :child (if attr (mutils/label-str metadata attr) "")]])))
 
-(defn labeled-el [metadata attr el]
-  [re-com/h-box
-   :gap "10px"
-   :children
-   [[label-with-tooltip metadata attr]
-    el]])
+(defn labeled-el
+  ([metadata attr el] (labeled-el metadata styles/wider-attr-label attr el))
+  ([metadata style attr el]
+   [re-com/h-box
+    :gap "10px"
+    :children
+    [[label-with-tooltip metadata style attr]
+     el]]))
 
 (defn v-box [els]
   [re-com/v-box


### PR DESCRIPTION
- Significant refactor of "New Form" interface code in views.forms.new. Reuse views.widgets machinery, improve code organization, and remove redundancies.
- Refactor events ns. A successful `GET /forms/new` request will now store the received mini-resources in a general-purpose way, with caching, just like `GET /applicationettings/new` does.
- Put form field metadata in the models.form ns. Validate to spec the data returned by GET /forms/new.
- Improvements to specs:
  - Add new spec namespaces for elicitiation-method, speaker, syntactic-category, and tag.
  - Improve spec for source: make crossref-source field optional.
  - Move specs from form to correct entity spec namespaces. Add specs for data returned by GET /forms/new.
- Label-related widgets can now accept a nil input attr and will display an empty label (that takes up space like a non-empty one) when the attr is nil.